### PR TITLE
Improve shared bill loading and draft state handling

### DIFF
--- a/app/b/[billId]/page.tsx
+++ b/app/b/[billId]/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react"
+import { ProBillSplitter } from "@/components/ProBillSplitter"
+
+export default function SharedBillPage() {
+  return (
+    <Suspense>
+      <ProBillSplitter />
+    </Suspense>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,48 @@
-"use client"
-
 import { Suspense } from "react"
+import { redirect } from "next/navigation"
 import { ProBillSplitter } from "@/components/ProBillSplitter"
+import { buildSharedBillPath, getSharedBillIdFromSearch, stripSharedBillParams } from "@/lib/sharing"
 
-export default function HomePage() {
+interface HomePageProps {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function getFirstParamValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) {
+    return value[0] ?? null
+  }
+
+  return value ?? null
+}
+
+export default async function HomePage({ searchParams }: HomePageProps) {
+  const resolvedSearchParams = (await searchParams) ?? {}
+  const legacyBillId =
+    getFirstParamValue(resolvedSearchParams.bill) ||
+    getFirstParamValue(resolvedSearchParams.share)
+
+  if (legacyBillId) {
+    const rawSearch = new URLSearchParams()
+
+    for (const [key, value] of Object.entries(resolvedSearchParams)) {
+      if (Array.isArray(value)) {
+        value.forEach((entry) => {
+          if (entry !== undefined) {
+            rawSearch.append(key, entry)
+          }
+        })
+        continue
+      }
+
+      if (value !== undefined) {
+        rawSearch.set(key, value)
+      }
+    }
+
+    const nextSearch = stripSharedBillParams(`?${rawSearch.toString()}`)
+    redirect(`${buildSharedBillPath(legacyBillId)}${nextSearch}`)
+  }
+
   return (
     <Suspense>
       <ProBillSplitter />

--- a/components/BillLookup.tsx
+++ b/components/BillLookup.tsx
@@ -81,7 +81,14 @@ export function BillLookup({ mode = "auto" }: BillLookupProps) {
       if (result.bill) {
         const migratedBill = migrateBillSchema(result.bill)
 
-        dispatch({ type: "LOAD_BILL", payload: migratedBill })
+        dispatch({
+          type: "LOAD_BILL",
+          payload: {
+            bill: migratedBill,
+            source: "shared",
+            sharedOriginBillId: trimmedId,
+          },
+        })
         setBillId("")
         setIsOpen(false)
 

--- a/components/BillLookup.tsx
+++ b/components/BillLookup.tsx
@@ -1,12 +1,13 @@
 "use client"
 
 import React, { useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { Label } from "@/components/ui/label"
 import { Search, Loader2 } from "lucide-react"
-import { extractBillIdFromInput, getBillFromCloud } from "@/lib/sharing"
+import { buildAppUrl, buildSharedBillPath, extractBillIdFromInput, getBillFromCloud } from "@/lib/sharing"
 import { useBill } from "@/contexts/BillContext"
 import { useToast } from "@/hooks/use-toast"
 import { migrateBillSchema } from "@/lib/validation"
@@ -23,6 +24,8 @@ export function BillLookup({ mode = "auto" }: BillLookupProps) {
   const { toast } = useToast()
   const analytics = useBillAnalytics()
   const isMobile = useIsMobile()
+  const router = useRouter()
+  const searchParams = useSearchParams()
   const [billId, setBillId] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
@@ -89,6 +92,10 @@ export function BillLookup({ mode = "auto" }: BillLookupProps) {
             sharedOriginBillId: trimmedId,
           },
         })
+        const nextParams = new URLSearchParams(searchParams.toString())
+        nextParams.delete("bill")
+        nextParams.delete("share")
+        router.push(buildAppUrl(buildSharedBillPath(trimmedId), nextParams.toString()), { scroll: false })
         setBillId("")
         setIsOpen(false)
 
@@ -139,7 +146,7 @@ export function BillLookup({ mode = "auto" }: BillLookupProps) {
           <SheetHeader className="p-6 pb-4">
             <SheetTitle>Load Bill by ID</SheetTitle>
             <SheetDescription>
-              Enter a bill ID to load a shared bill. You can find the bill ID in the share URL.
+              Enter a bill ID to load a shared bill. You can paste the full share link too.
             </SheetDescription>
           </SheetHeader>
           <div className="px-6 pb-6 space-y-4">
@@ -165,7 +172,7 @@ export function BillLookup({ mode = "auto" }: BillLookupProps) {
                 <p className="text-xs text-destructive">{error}</p>
               )}
               <p className="text-xs text-muted-foreground">
-                Example: If the URL is <code className="px-1 bg-muted rounded text-[10px]">?bill=1763442653885-vlpkbu4</code>,
+                Example: If the URL is <code className="px-1 bg-muted rounded text-[10px]">/b/1763442653885-vlpkbu4</code>,
                 enter <code className="px-1 bg-muted rounded text-[10px]">1763442653885-vlpkbu4</code>
               </p>
             </div>

--- a/components/BillSourceIndicator.tsx
+++ b/components/BillSourceIndicator.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { Copy, Link2 } from "lucide-react"
+import { useBill } from "@/contexts/BillContext"
+import { cn } from "@/lib/utils"
+
+const billSourceConfig = {
+  shared: {
+    icon: Link2,
+    label: "Viewing shared bill",
+    className: "text-sky-700 bg-sky-50",
+  },
+  shared_copy: {
+    icon: Copy,
+    label: "Editing local copy",
+    className: "text-amber-700 bg-amber-50",
+  },
+} as const
+
+export function BillSourceIndicator({ className }: { className?: string }) {
+  const { state } = useBill()
+
+  if (state.billSource === "draft") {
+    return null
+  }
+
+  const config = billSourceConfig[state.billSource]
+  const Icon = config.icon
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium",
+        config.className,
+        className
+      )}
+    >
+      <Icon className="h-3 w-3" />
+      <span>{config.label}</span>
+    </span>
+  )
+}

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -674,7 +674,14 @@ function DesktopBillSplitter() {
       }
 
       const migratedBill = migrateBillSchema(result.bill)
-      dispatch({ type: 'LOAD_BILL', payload: migratedBill })
+      dispatch({
+        type: 'LOAD_BILL',
+        payload: {
+          bill: migratedBill,
+          source: 'shared',
+          sharedOriginBillId: trimmedId,
+        },
+      })
       toast({
         title: "Bill loaded!",
         description: `Loaded "${migratedBill.title}"`,

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -32,7 +32,7 @@ import { BillSourceIndicator } from '@/components/BillSourceIndicator'
 import { SyncStatusIndicator } from '@/components/SyncStatusIndicator'
 import { useBillAnalytics } from '@/hooks/use-analytics'
 import { TIMING } from '@/lib/constants'
-import { extractBillIdFromInput, getBillFromCloud, stripSharedBillParams } from '@/lib/sharing'
+import { buildAppUrl, buildSharedBillPath, extractBillIdFromInput, getBillFromCloud, stripSharedBillLocation } from '@/lib/sharing'
 import { migrateBillSchema } from '@/lib/validation'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { MobileSpreadsheetView } from '@/components/MobileSpreadsheetView'
@@ -513,8 +513,8 @@ function DesktopBillSplitter() {
   }, [dispatch, toast])
 
   const confirmNewBill = useCallback(() => {
-    const nextSearch = stripSharedBillParams(searchParams.toString())
-    router.replace(nextSearch ? `${pathname}${nextSearch}` : pathname, { scroll: false })
+    const nextUrl = stripSharedBillLocation(pathname, searchParams.toString())
+    router.replace(nextUrl, { scroll: false })
     dispatch({ type: 'NEW_BILL' })
     toast({ title: "New bill created", variant: "success" })
     analytics.trackBillCreated()
@@ -683,6 +683,10 @@ function DesktopBillSplitter() {
           sharedOriginBillId: trimmedId,
         },
       })
+      const nextParams = new URLSearchParams(searchParams.toString())
+      nextParams.delete('bill')
+      nextParams.delete('share')
+      router.push(buildAppUrl(buildSharedBillPath(trimmedId), nextParams.toString()), { scroll: false })
       toast({
         title: "Bill loaded!",
         description: `Loaded "${migratedBill.title}"`,
@@ -696,7 +700,7 @@ function DesktopBillSplitter() {
         setIsLoadingBill(false)
       }
     }
-  }, [billId, dispatch, toast, analytics])
+  }, [billId, dispatch, router, searchParams, toast, analytics])
 
   // --- Copy Breakdown ---
   const copyBreakdown = useCallback(async () => {

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -31,7 +31,7 @@ import { ShareBill } from '@/components/ShareBill'
 import { SyncStatusIndicator } from '@/components/SyncStatusIndicator'
 import { useBillAnalytics } from '@/hooks/use-analytics'
 import { TIMING } from '@/lib/constants'
-import { extractBillIdFromInput, getBillFromCloud } from '@/lib/sharing'
+import { extractBillIdFromInput, getBillFromCloud, stripSharedBillParams } from '@/lib/sharing'
 import { migrateBillSchema } from '@/lib/validation'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { MobileSpreadsheetView } from '@/components/MobileSpreadsheetView'
@@ -512,6 +512,8 @@ function DesktopBillSplitter() {
   }, [dispatch, toast])
 
   const confirmNewBill = useCallback(() => {
+    const nextSearch = stripSharedBillParams(searchParams.toString())
+    router.replace(nextSearch ? `${pathname}${nextSearch}` : pathname, { scroll: false })
     dispatch({ type: 'NEW_BILL' })
     toast({ title: "New bill created", variant: "success" })
     analytics.trackBillCreated()
@@ -520,7 +522,7 @@ function DesktopBillSplitter() {
     )
     newBillSourceRef.current = "button"
     setIsNewBillDialogOpen(false)
-  }, [dispatch, toast, analytics])
+  }, [analytics, dispatch, pathname, router, searchParams, toast])
 
   const openDeleteDialog = useCallback((item: Item) => {
     setPendingDeleteItem(item)

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -28,6 +28,7 @@ import { cn, formatCurrencyWithCents as formatCurrencySimple } from '@/lib/utils
 import { generateSummaryText, copyToClipboard } from '@/lib/export'
 import { useToast } from '@/hooks/use-toast'
 import { ShareBill } from '@/components/ShareBill'
+import { BillSourceIndicator } from '@/components/BillSourceIndicator'
 import { SyncStatusIndicator } from '@/components/SyncStatusIndicator'
 import { useBillAnalytics } from '@/hooks/use-analytics'
 import { TIMING } from '@/lib/constants'
@@ -1094,7 +1095,10 @@ function DesktopBillSplitter() {
                   name="bill-title"
                   autoComplete="off"
                 />
-                <SyncStatusIndicator inline />
+                <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                  <SyncStatusIndicator inline />
+                  <BillSourceIndicator />
+                </div>
               </div>
             </div>
 

--- a/contexts/BillContext.tsx
+++ b/contexts/BillContext.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 import { createContext, useContext, useReducer, useEffect, useRef } from "react"
 import { getBillFromCloud, getSharedBillIdFromSearch, storeBillInCloud } from "@/lib/sharing"
 import { isMigratableBill, isRecord, migrateBillSchema, type MigratableBill } from "@/lib/validation"
-import type { Bill, BillStatus, Item, Person, SyncStatus, TaxTipAllocation } from "@/lib/bill-types"
+import type { Bill, BillSource, BillStatus, Item, Person, SyncStatus, TaxTipAllocation } from "@/lib/bill-types"
 
 // State and Actions
 interface BillState {
@@ -12,6 +12,8 @@ interface BillState {
   history: Bill[]
   historyIndex: number
   maxHistorySize: number
+  billSource: BillSource
+  sharedOriginBillId: string | null
   syncStatus: SyncStatus
   lastSyncTime: number | null
 }
@@ -31,7 +33,14 @@ type BillAction =
   | { type: "UPDATE_ITEM"; payload: Item }
   | { type: "REMOVE_ITEM"; payload: string }
   | { type: "REORDER_ITEMS"; payload: { startIndex: number; endIndex: number } }
-  | { type: "LOAD_BILL"; payload: Bill }
+  | {
+      type: "LOAD_BILL"
+      payload: {
+        bill: Bill
+        source: "draft" | "shared"
+        sharedOriginBillId?: string | null
+      }
+    }
   | { type: "NEW_BILL" }
   | { type: "UNDO" }
   | { type: "REDO" }
@@ -90,50 +99,100 @@ const initialState: BillState = {
   history: [],
   historyIndex: -1,
   maxHistorySize: 50,
+  billSource: "draft",
+  sharedOriginBillId: null,
   syncStatus: "never_synced",
   lastSyncTime: null,
 }
 
+const EDITABLE_BILL_ACTIONS = new Set<BillAction["type"]>([
+  "SET_BILL_TITLE",
+  "SET_BILL_STATUS",
+  "SET_NOTES",
+  "SET_TAX",
+  "SET_TIP",
+  "SET_DISCOUNT",
+  "SET_TAX_TIP_ALLOCATION",
+  "ADD_PERSON",
+  "UPDATE_PERSON",
+  "REMOVE_PERSON",
+  "ADD_ITEM",
+  "UPDATE_ITEM",
+  "REMOVE_ITEM",
+  "REORDER_ITEMS",
+])
+
+const createSharedBillCopy = (state: BillState): BillState => {
+  const sharedOriginBillId = state.sharedOriginBillId ?? state.currentBill.id
+  const currentBill = {
+    ...structuredClone(state.currentBill),
+    id: simpleUUID(),
+  }
+
+  return {
+    ...state,
+    currentBill,
+    billSource: "shared_copy",
+    sharedOriginBillId,
+    syncStatus: "never_synced",
+    lastSyncTime: null,
+  }
+}
+
+const getEditableState = (state: BillState, actionType: BillAction["type"]): BillState => {
+  if (state.billSource !== "shared") {
+    return state
+  }
+
+  if (!EDITABLE_BILL_ACTIONS.has(actionType)) {
+    return state
+  }
+
+  return createSharedBillCopy(state)
+}
+
 // Reducer
 function billReducer(state: BillState, action: BillAction): BillState {
+  const editableState = getEditableState(state, action.type)
+
   switch (action.type) {
     case "SET_BILL_TITLE": {
-      const newBill = { ...state.currentBill, title: action.payload }
-      return addToHistory(state, newBill)
+      const newBill = { ...editableState.currentBill, title: action.payload }
+      return addToHistory(editableState, newBill)
     }
 
     case "SET_BILL_STATUS": {
-      const newBill = { ...state.currentBill, status: action.payload }
-      return addToHistory(state, newBill)
+      const newBill = { ...editableState.currentBill, status: action.payload }
+      return addToHistory(editableState, newBill)
     }
 
     case "SET_NOTES": {
-      const newBill = { ...state.currentBill, notes: action.payload }
-      return addToHistory(state, newBill)
+      const newBill = { ...editableState.currentBill, notes: action.payload }
+      return addToHistory(editableState, newBill)
     }
 
     case "SET_TAX": {
-      const newBill = { ...state.currentBill, tax: action.payload }
-      return addToHistory(state, newBill)
+      const newBill = { ...editableState.currentBill, tax: action.payload }
+      return addToHistory(editableState, newBill)
     }
 
     case "SET_TIP": {
-      const newBill = { ...state.currentBill, tip: action.payload }
-      return addToHistory(state, newBill)
+      const newBill = { ...editableState.currentBill, tip: action.payload }
+      return addToHistory(editableState, newBill)
     }
 
     case "SET_DISCOUNT": {
-      const newBill = { ...state.currentBill, discount: action.payload }
-      return addToHistory(state, newBill)
+      const newBill = { ...editableState.currentBill, discount: action.payload }
+      return addToHistory(editableState, newBill)
     }
 
     case "SET_TAX_TIP_ALLOCATION": {
-      const newBill = { ...state.currentBill, taxTipAllocation: action.payload }
-      return addToHistory(state, newBill)
+      const newBill = { ...editableState.currentBill, taxTipAllocation: action.payload }
+      return addToHistory(editableState, newBill)
     }
 
     case "ADD_PERSON": {
-      const usedColors = new Set(state.currentBill.people.map((p) => p.color))
+      const usedColors = new Set(editableState.currentBill.people.map((p) => p.color))
       let newColor = ""
 
       if (action.payload.color) {
@@ -147,33 +206,33 @@ function billReducer(state: BillState, action: BillAction): BillState {
         id: simpleUUID(),
         name: action.payload.name,
         color: newColor,
-        colorIdx: state.currentBill.people.length % 6, // Assign color index for Pro design (0-5)
+        colorIdx: editableState.currentBill.people.length % 6, // Assign color index for Pro design (0-5)
       }
       const newBill = {
-        ...state.currentBill,
-        people: [...state.currentBill.people, newPerson],
+        ...editableState.currentBill,
+        people: [...editableState.currentBill.people, newPerson],
       }
-      return addToHistory(state, newBill)
+      return addToHistory(editableState, newBill)
     }
 
     case "UPDATE_PERSON": {
       const newBill = {
-        ...state.currentBill,
-        people: state.currentBill.people.map((p) => (p.id === action.payload.id ? action.payload : p)),
+        ...editableState.currentBill,
+        people: editableState.currentBill.people.map((p) => (p.id === action.payload.id ? action.payload : p)),
       }
-      return addToHistory(state, newBill)
+      return addToHistory(editableState, newBill)
     }
 
     case "REMOVE_PERSON": {
       const newBill = {
-        ...state.currentBill,
-        people: state.currentBill.people.filter((p) => p.id !== action.payload),
-        items: state.currentBill.items.map((item) => ({
+        ...editableState.currentBill,
+        people: editableState.currentBill.people.filter((p) => p.id !== action.payload),
+        items: editableState.currentBill.items.map((item) => ({
           ...item,
           splitWith: item.splitWith.filter((id) => id !== action.payload),
         })),
       }
-      return addToHistory(state, newBill)
+      return addToHistory(editableState, newBill)
     }
 
     case "ADD_ITEM": {
@@ -182,46 +241,53 @@ function billReducer(state: BillState, action: BillAction): BillState {
         id: simpleUUID(),
       }
       const newBill = {
-        ...state.currentBill,
-        items: [...state.currentBill.items, newItem],
+        ...editableState.currentBill,
+        items: [...editableState.currentBill.items, newItem],
       }
-      return addToHistory(state, newBill)
+      return addToHistory(editableState, newBill)
     }
 
     case "UPDATE_ITEM": {
       const newBill = {
-        ...state.currentBill,
-        items: state.currentBill.items.map((item) => (item.id === action.payload.id ? action.payload : item)),
+        ...editableState.currentBill,
+        items: editableState.currentBill.items.map((item) => (item.id === action.payload.id ? action.payload : item)),
       }
-      return addToHistory(state, newBill)
+      return addToHistory(editableState, newBill)
     }
 
     case "REMOVE_ITEM": {
       const newBill = {
-        ...state.currentBill,
-        items: state.currentBill.items.filter((item) => item.id !== action.payload),
+        ...editableState.currentBill,
+        items: editableState.currentBill.items.filter((item) => item.id !== action.payload),
       }
-      return addToHistory(state, newBill)
+      return addToHistory(editableState, newBill)
     }
 
     case "REORDER_ITEMS": {
       const { startIndex, endIndex } = action.payload
-      const newItems = Array.from(state.currentBill.items)
+      const newItems = Array.from(editableState.currentBill.items)
       const [removed] = newItems.splice(startIndex, 1)
       newItems.splice(endIndex, 0, removed)
       const newBill = {
-        ...state.currentBill,
+        ...editableState.currentBill,
         items: newItems,
       }
-      return addToHistory(state, newBill)
+      return addToHistory(editableState, newBill)
     }
 
     case "LOAD_BILL": {
       return {
         ...initialState,
-        currentBill: action.payload,
+        currentBill: action.payload.bill,
         history: [],
         historyIndex: -1,
+        billSource: action.payload.source,
+        sharedOriginBillId:
+          action.payload.source === "shared"
+            ? action.payload.sharedOriginBillId ?? action.payload.bill.id
+            : action.payload.sharedOriginBillId ?? null,
+        syncStatus: action.payload.source === "shared" ? "synced" : "never_synced",
+        lastSyncTime: action.payload.source === "shared" ? Date.now() : null,
       }
     }
 
@@ -232,6 +298,10 @@ function billReducer(state: BillState, action: BillAction): BillState {
         currentBill: newBill,
         history: [],
         historyIndex: -1,
+        billSource: "draft",
+        sharedOriginBillId: null,
+        syncStatus: "never_synced",
+        lastSyncTime: null,
       }
     }
 
@@ -402,7 +472,13 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
           if (saved) {
             const bill: unknown = JSON.parse(saved)
             if (isMigratableBill(bill)) {
-              dispatch({ type: "LOAD_BILL", payload: migrateBillSchema(bill) })
+              dispatch({
+                type: "LOAD_BILL",
+                payload: {
+                  bill: migrateBillSchema(bill),
+                  source: "draft",
+                },
+              })
             }
           }
         } catch (error) {
@@ -417,7 +493,14 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
 
         if (cloudResult.bill) {
           const migratedBill = migrateBillSchema(cloudResult.bill)
-          dispatch({ type: "LOAD_BILL", payload: migratedBill })
+          dispatch({
+            type: "LOAD_BILL",
+            payload: {
+              bill: migratedBill,
+              source: "shared",
+              sharedOriginBillId: sharedBillId,
+            },
+          })
 
           if (typeof window !== "undefined") {
             const event = new CustomEvent("bill-loaded-success", {
@@ -437,7 +520,14 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
 
         if (localSharedBill) {
           const migratedBill = migrateBillSchema(localSharedBill)
-          dispatch({ type: "LOAD_BILL", payload: migratedBill })
+          dispatch({
+            type: "LOAD_BILL",
+            payload: {
+              bill: migratedBill,
+              source: "shared",
+              sharedOriginBillId: sharedBillId,
+            },
+          })
 
           if (typeof window !== "undefined") {
             const event = new CustomEvent("bill-loaded-success", {

--- a/contexts/BillContext.tsx
+++ b/contexts/BillContext.tsx
@@ -612,7 +612,13 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
   // Debounced persistence whenever the active bill changes (500ms delay)
   useEffect(() => {
     const timeoutId = setTimeout(() => {
+      const hasSharedBillInLocation = getSharedBillIdFromLocation() !== null
+
       try {
+        if (hasSharedBillInLocation && state.billSource === "draft") {
+          return
+        }
+
         saveBillToLocalStorage(state.currentBill)
 
         if (state.billSource === "shared") {
@@ -623,7 +629,7 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
       } catch (error) {
         console.error("Failed to save bill to localStorage:", error)
 
-        if (state.billSource === "shared") {
+        if (state.billSource === "shared" || (hasSharedBillInLocation && state.billSource === "draft")) {
           return
         }
 
@@ -655,8 +661,9 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
   // Debounced auto-sync to cloud when bill changes
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | undefined
+    const hasSharedBillInLocation = getSharedBillIdFromLocation() !== null
     
-    if (state.billSource !== "shared" && state.syncStatus === "never_synced") {
+    if (!hasSharedBillInLocation && state.billSource !== "shared" && state.syncStatus === "never_synced") {
       timeoutId = setTimeout(() => {
         syncToCloud()
       }, 2000) // 2-second debounce

--- a/contexts/BillContext.tsx
+++ b/contexts/BillContext.tsx
@@ -609,17 +609,23 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  // Debounced auto-save to localStorage whenever state changes (500ms delay)
+  // Debounced persistence whenever the active bill changes (500ms delay)
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       try {
-        // Save current bill to main storage
-        localStorage.setItem("splitSimple_currentBill", JSON.stringify(state.currentBill))
-
-        // Also save to shared bills storage for sharing
         saveBillToLocalStorage(state.currentBill)
+
+        if (state.billSource === "shared") {
+          return
+        }
+
+        localStorage.setItem("splitSimple_currentBill", JSON.stringify(state.currentBill))
       } catch (error) {
         console.error("Failed to save bill to localStorage:", error)
+
+        if (state.billSource === "shared") {
+          return
+        }
 
         // Try to save with a smaller payload if the bill is too large
         try {
@@ -644,13 +650,13 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
     }, 500)
 
     return () => clearTimeout(timeoutId)
-  }, [state.currentBill])
+  }, [state.billSource, state.currentBill])
 
   // Debounced auto-sync to cloud when bill changes
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | undefined
     
-    if (state.syncStatus === "never_synced") {
+    if (state.billSource !== "shared" && state.syncStatus === "never_synced") {
       timeoutId = setTimeout(() => {
         syncToCloud()
       }, 2000) // 2-second debounce
@@ -661,7 +667,7 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
         clearTimeout(timeoutId)
       }
     }
-  }, [state.currentBill, state.syncStatus])
+  }, [state.billSource, state.currentBill, state.syncStatus])
 
   return <BillContext.Provider value={{ state, dispatch, canUndo, canRedo, syncToCloud }}>{children}</BillContext.Provider>
 }

--- a/contexts/BillContext.tsx
+++ b/contexts/BillContext.tsx
@@ -2,7 +2,8 @@
 
 import type React from "react"
 import { createContext, useCallback, useContext, useReducer, useEffect, useRef } from "react"
-import { getBillFromCloud, getSharedBillIdFromSearch, storeBillInCloud, stripSharedBillParams } from "@/lib/sharing"
+import { getBillFromCloud, getSharedBillIdFromLocationParts, storeBillInCloud, stripSharedBillLocation } from "@/lib/sharing"
+import { normalizeBillForPersistence } from "@/lib/persisted-bill"
 import { isMigratableBill, isRecord, migrateBillSchema, type MigratableBill } from "@/lib/validation"
 import type { Bill, BillSource, BillStatus, Item, Person, SyncStatus, TaxTipAllocation } from "@/lib/bill-types"
 
@@ -354,6 +355,7 @@ function billReducer(state: BillState, action: BillAction): BillState {
 // Sharing functionality
 const saveBillToLocalStorage = (bill: Bill) => {
   try {
+    const normalizedBill = normalizeBillForPersistence(bill)
     const billsData = localStorage.getItem("splitsimple_bills") || "{}"
     const parsedBills: unknown = JSON.parse(billsData)
     const bills: Record<string, unknown> = {}
@@ -362,7 +364,7 @@ const saveBillToLocalStorage = (bill: Bill) => {
         bills[id] = storedBill
       }
     }
-    bills[bill.id] = bill
+    bills[normalizedBill.id] = normalizedBill
     localStorage.setItem("splitsimple_bills", JSON.stringify(bills))
   } catch (error) {
     console.error("Failed to save bill to localStorage:", error)
@@ -387,21 +389,14 @@ const loadBillFromLocalStorage = (billId: string): MigratableBill | null => {
 const getSharedBillIdFromLocation = (): string | null => {
   if (typeof window === "undefined") return null
 
-  return getSharedBillIdFromSearch(window.location.search)
+  return getSharedBillIdFromLocationParts(window.location.pathname, window.location.search)
 }
 
 const clearSharedBillParamsFromLocation = () => {
   if (typeof window === "undefined") return
 
-  const nextSearch = stripSharedBillParams(window.location.search)
-  const nextUrl = `${window.location.pathname}${nextSearch}${window.location.hash}`
+  const nextUrl = stripSharedBillLocation(window.location.pathname, window.location.search, window.location.hash)
   window.history.replaceState(window.history.state, "", nextUrl)
-}
-
-const generateShareUrl = (billId: string): string => {
-  // Ensure we always use the root path for sharing
-  const baseUrl = typeof window !== 'undefined' ? window.location.origin : ''
-  return `${baseUrl}/?bill=${billId}`
 }
 
 function addToHistory(state: BillState, newBill: Bill): BillState {
@@ -625,7 +620,7 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
           return
         }
 
-        localStorage.setItem("splitSimple_currentBill", JSON.stringify(state.currentBill))
+        localStorage.setItem("splitSimple_currentBill", JSON.stringify(normalizeBillForPersistence(state.currentBill)))
       } catch (error) {
         console.error("Failed to save bill to localStorage:", error)
 
@@ -636,8 +631,8 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
         // Try to save with a smaller payload if the bill is too large
         try {
           const minimalBill = {
-            ...state.currentBill,
-            items: state.currentBill.items.map(item => ({
+            ...normalizeBillForPersistence(state.currentBill),
+            items: normalizeBillForPersistence(state.currentBill).items.map(item => ({
               id: item.id,
               name: item.name,
               price: item.price,

--- a/contexts/BillContext.tsx
+++ b/contexts/BillContext.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import type React from "react"
-import { createContext, useContext, useReducer, useEffect, useRef } from "react"
-import { getBillFromCloud, getSharedBillIdFromSearch, storeBillInCloud } from "@/lib/sharing"
+import { createContext, useCallback, useContext, useReducer, useEffect, useRef } from "react"
+import { getBillFromCloud, getSharedBillIdFromSearch, storeBillInCloud, stripSharedBillParams } from "@/lib/sharing"
 import { isMigratableBill, isRecord, migrateBillSchema, type MigratableBill } from "@/lib/validation"
 import type { Bill, BillSource, BillStatus, Item, Person, SyncStatus, TaxTipAllocation } from "@/lib/bill-types"
 
@@ -390,6 +390,14 @@ const getSharedBillIdFromLocation = (): string | null => {
   return getSharedBillIdFromSearch(window.location.search)
 }
 
+const clearSharedBillParamsFromLocation = () => {
+  if (typeof window === "undefined") return
+
+  const nextSearch = stripSharedBillParams(window.location.search)
+  const nextUrl = `${window.location.pathname}${nextSearch}${window.location.hash}`
+  window.history.replaceState(window.history.state, "", nextUrl)
+}
+
 const generateShareUrl = (billId: string): string => {
   // Ensure we always use the root path for sharing
   const baseUrl = typeof window !== 'undefined' ? window.location.origin : ''
@@ -425,29 +433,41 @@ const BillContext = createContext<{
 
 // Provider
 export function BillProvider({ children }: { children: React.ReactNode }) {
-  const [state, dispatch] = useReducer(billReducer, initialState)
+  const [state, rawDispatch] = useReducer(billReducer, initialState)
   const sharedBillIdRef = useRef<string | null>(null)
   const sharedBillLoadRequestRef = useRef(0)
 
   const canUndo = state.historyIndex >= 0
   const canRedo = state.historyIndex < state.history.length - 1
 
+  const dispatch = useCallback((action: BillAction) => {
+    const shouldClearSharedUrl =
+      state.billSource === "shared" && (EDITABLE_BILL_ACTIONS.has(action.type) || action.type === "NEW_BILL")
+
+    if (shouldClearSharedUrl) {
+      clearSharedBillParamsFromLocation()
+    }
+
+    rawDispatch(action)
+  }, [state.billSource])
+
   // Auto-sync to cloud functionality
   const syncToCloud = async () => {
+    if (state.billSource === "shared") return
     if (state.syncStatus === "syncing") return // Avoid duplicate sync calls
     
-    dispatch({ type: "SYNC_TO_CLOUD" })
+    rawDispatch({ type: "SYNC_TO_CLOUD" })
     
     try {
       const result = await storeBillInCloud(state.currentBill)
       if (result.success) {
-        dispatch({ type: "SET_SYNC_STATUS", payload: "synced" })
+        rawDispatch({ type: "SET_SYNC_STATUS", payload: "synced" })
       } else {
-        dispatch({ type: "SET_SYNC_STATUS", payload: "error" })
+        rawDispatch({ type: "SET_SYNC_STATUS", payload: "error" })
       }
     } catch (error) {
       console.error("Sync to cloud failed:", error)
-      dispatch({ type: "SET_SYNC_STATUS", payload: "error" })
+      rawDispatch({ type: "SET_SYNC_STATUS", payload: "error" })
     }
   }
 
@@ -472,7 +492,7 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
           if (saved) {
             const bill: unknown = JSON.parse(saved)
             if (isMigratableBill(bill)) {
-              dispatch({
+              rawDispatch({
                 type: "LOAD_BILL",
                 payload: {
                   bill: migrateBillSchema(bill),
@@ -493,7 +513,7 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
 
         if (cloudResult.bill) {
           const migratedBill = migrateBillSchema(cloudResult.bill)
-          dispatch({
+          rawDispatch({
             type: "LOAD_BILL",
             payload: {
               bill: migratedBill,
@@ -520,7 +540,7 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
 
         if (localSharedBill) {
           const migratedBill = migrateBillSchema(localSharedBill)
-          dispatch({
+          rawDispatch({
             type: "LOAD_BILL",
             payload: {
               bill: migratedBill,

--- a/contexts/BillContext.tsx
+++ b/contexts/BillContext.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import type React from "react"
-import { createContext, useContext, useReducer, useEffect } from "react"
-import { getBillFromCloud, storeBillInCloud } from "@/lib/sharing"
+import { createContext, useContext, useReducer, useEffect, useRef } from "react"
+import { getBillFromCloud, getSharedBillIdFromSearch, storeBillInCloud } from "@/lib/sharing"
 import { isMigratableBill, isRecord, migrateBillSchema, type MigratableBill } from "@/lib/validation"
 import type { Bill, BillStatus, Item, Person, SyncStatus, TaxTipAllocation } from "@/lib/bill-types"
 
@@ -317,8 +317,7 @@ const loadBillFromLocalStorage = (billId: string): MigratableBill | null => {
 const getSharedBillIdFromLocation = (): string | null => {
   if (typeof window === "undefined") return null
 
-  const params = new URLSearchParams(window.location.search)
-  return params.get("bill") || params.get("share")
+  return getSharedBillIdFromSearch(window.location.search)
 }
 
 const generateShareUrl = (billId: string): string => {
@@ -357,6 +356,8 @@ const BillContext = createContext<{
 // Provider
 export function BillProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(billReducer, initialState)
+  const sharedBillIdRef = useRef<string | null>(null)
+  const sharedBillLoadRequestRef = useRef(0)
 
   const canUndo = state.historyIndex >= 0
   const canRedo = state.historyIndex < state.history.length - 1
@@ -384,6 +385,15 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const loadBillFromLocation = async (loadLocalFallback: boolean) => {
       const sharedBillId = getSharedBillIdFromLocation()
+      const previousSharedBillId = sharedBillIdRef.current
+      sharedBillIdRef.current = sharedBillId
+
+      if (sharedBillId === previousSharedBillId && sharedBillId !== null) {
+        return
+      }
+
+      const requestId = ++sharedBillLoadRequestRef.current
+
       if (!sharedBillId) {
         if (!loadLocalFallback) return
 
@@ -403,6 +413,8 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
 
       try {
         const cloudResult = await getBillFromCloud(sharedBillId)
+        if (sharedBillLoadRequestRef.current !== requestId) return
+
         if (cloudResult.bill) {
           const migratedBill = migrateBillSchema(cloudResult.bill)
           dispatch({ type: "LOAD_BILL", payload: migratedBill })
@@ -421,6 +433,8 @@ export function BillProvider({ children }: { children: React.ReactNode }) {
         }
 
         const localSharedBill = loadBillFromLocalStorage(sharedBillId)
+        if (sharedBillLoadRequestRef.current !== requestId) return
+
         if (localSharedBill) {
           const migratedBill = migrateBillSchema(localSharedBill)
           dispatch({ type: "LOAD_BILL", payload: migratedBill })

--- a/contexts/__tests__/BillContext.test.tsx
+++ b/contexts/__tests__/BillContext.test.tsx
@@ -508,5 +508,31 @@ describe('BillContext', () => {
       expect(result.current.state.currentBill.title).toBe('Loaded After Navigation')
       expect(getBillFromCloud).toHaveBeenCalledWith(sharedBill.id)
     })
+
+    it('should not refetch when unrelated query params change for the same shared bill', async () => {
+      const sharedBill = createMockBill({
+        id: '1780007206455-yojajgt',
+        title: 'Stable Shared Bill',
+      })
+
+      jest.mocked(getBillFromCloud).mockResolvedValue({ bill: sharedBill })
+      window.history.replaceState({}, '', `/?bill=${sharedBill.id}`)
+
+      const { result } = renderHook(() => useBill(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.state.currentBill.id).toBe(sharedBill.id)
+      })
+      expect(getBillFromCloud).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        window.history.pushState({}, '', `/?bill=${sharedBill.id}&view=breakdown`)
+      })
+
+      await waitFor(() => {
+        expect(getBillFromCloud).toHaveBeenCalledTimes(1)
+      })
+      expect(result.current.state.currentBill.title).toBe('Stable Shared Bill')
+    })
   })
 })

--- a/contexts/__tests__/BillContext.test.tsx
+++ b/contexts/__tests__/BillContext.test.tsx
@@ -458,7 +458,13 @@ describe('BillContext', () => {
       })
       
       act(() => {
-        result.current.dispatch({ type: 'LOAD_BILL', payload: testBill })
+        result.current.dispatch({
+          type: 'LOAD_BILL',
+          payload: {
+            bill: testBill,
+            source: 'draft',
+          },
+        })
       })
       
       expect(result.current.state.currentBill.title).toBe('Loaded Bill')

--- a/contexts/__tests__/BillContext.test.tsx
+++ b/contexts/__tests__/BillContext.test.tsx
@@ -17,7 +17,21 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 )
 
 describe('BillContext', () => {
+  let storage: Record<string, string>
+
   beforeEach(() => {
+    storage = {}
+    jest.mocked(localStorage.getItem).mockImplementation((key: string) => storage[key] ?? null)
+    jest.mocked(localStorage.setItem).mockImplementation((key: string, value: string) => {
+      storage[key] = value
+    })
+    jest.mocked(localStorage.removeItem).mockImplementation((key: string) => {
+      delete storage[key]
+    })
+    jest.mocked(localStorage.clear).mockImplementation(() => {
+      storage = {}
+    })
+
     // Clear localStorage before each test
     localStorage.clear()
     window.history.replaceState({}, '', '/')
@@ -32,6 +46,8 @@ describe('BillContext', () => {
       expect(result.current.state.currentBill.people[0].name).toBe('Person 1')
       expect(result.current.state.currentBill.items).toEqual([])
       expect(result.current.state.currentBill.status).toBe('active')
+      expect(result.current.state.billSource).toBe('draft')
+      expect(result.current.state.sharedOriginBillId).toBeNull()
       expect(result.current.state.syncStatus).toBe('never_synced')
     })
 
@@ -471,6 +487,8 @@ describe('BillContext', () => {
       expect(result.current.state.currentBill.status).toBe('active')
       expect(result.current.state.currentBill.people).toHaveLength(1)
       expect(result.current.state.currentBill.items).toHaveLength(1)
+      expect(result.current.state.billSource).toBe('draft')
+      expect(result.current.state.sharedOriginBillId).toBeNull()
       expect(result.current.state.history).toEqual([])
     })
 
@@ -490,6 +508,9 @@ describe('BillContext', () => {
         expect(result.current.state.currentBill.id).toBe(sharedBill.id)
       })
       expect(result.current.state.currentBill.title).toBe('Shared Bill')
+      expect(result.current.state.billSource).toBe('shared')
+      expect(result.current.state.sharedOriginBillId).toBe(sharedBill.id)
+      expect(result.current.state.syncStatus).toBe('synced')
       expect(getBillFromCloud).toHaveBeenCalledWith(sharedBill.id)
     })
 
@@ -512,6 +533,7 @@ describe('BillContext', () => {
         expect(result.current.state.currentBill.id).toBe(sharedBill.id)
       })
       expect(result.current.state.currentBill.title).toBe('Loaded After Navigation')
+      expect(result.current.state.billSource).toBe('shared')
       expect(getBillFromCloud).toHaveBeenCalledWith(sharedBill.id)
     })
 
@@ -539,6 +561,63 @@ describe('BillContext', () => {
         expect(getBillFromCloud).toHaveBeenCalledTimes(1)
       })
       expect(result.current.state.currentBill.title).toBe('Stable Shared Bill')
+    })
+
+    it('should fork a shared bill into a local copy on first edit', async () => {
+      const sharedBill = createMockBill({
+        id: '1780007206455-yojajgt',
+        title: 'Shared Bill',
+      })
+
+      jest.mocked(getBillFromCloud).mockResolvedValue({ bill: sharedBill })
+      window.history.replaceState({}, '', `/?bill=${sharedBill.id}`)
+
+      const { result } = renderHook(() => useBill(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.state.currentBill.id).toBe(sharedBill.id)
+      })
+
+      act(() => {
+        result.current.dispatch({ type: 'SET_BILL_TITLE', payload: 'Edited Copy' })
+      })
+
+      expect(result.current.state.currentBill.id).not.toBe(sharedBill.id)
+      expect(result.current.state.currentBill.title).toBe('Edited Copy')
+      expect(result.current.state.billSource).toBe('shared_copy')
+      expect(result.current.state.sharedOriginBillId).toBe(sharedBill.id)
+      expect(window.location.search).toBe('')
+    })
+
+    it('should preserve the current draft when a shared bill is loaded', async () => {
+      const localDraft = createMockBill({
+        id: 'draft-bill-id',
+        title: 'Local Draft',
+      })
+      const sharedBill = createMockBill({
+        id: '1780007206455-yojajgt',
+        title: 'Shared Bill',
+      })
+
+      localStorage.setItem('splitSimple_currentBill', JSON.stringify(localDraft))
+      jest.mocked(getBillFromCloud).mockResolvedValue({ bill: sharedBill })
+      window.history.replaceState({}, '', `/?bill=${sharedBill.id}`)
+
+      const { result } = renderHook(() => useBill(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.state.currentBill.id).toBe(sharedBill.id)
+      })
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 600))
+      })
+
+      const savedDraft = JSON.parse(localStorage.getItem('splitSimple_currentBill') || '{}')
+      const sharedCache = JSON.parse(localStorage.getItem('splitsimple_bills') || '{}')
+
+      expect(savedDraft.title).toBe('Local Draft')
+      expect(sharedCache[sharedBill.id]?.title).toBe('Shared Bill')
     })
   })
 })

--- a/contexts/__tests__/BillContext.test.tsx
+++ b/contexts/__tests__/BillContext.test.tsx
@@ -514,6 +514,25 @@ describe('BillContext', () => {
       expect(getBillFromCloud).toHaveBeenCalledWith(sharedBill.id)
     })
 
+    it('should load a shared bill from the dedicated shared route on mount', async () => {
+      const sharedBill = createMockBill({
+        id: '1780007206455-yojajgt',
+        title: 'Path Shared Bill',
+      })
+
+      jest.mocked(getBillFromCloud).mockResolvedValue({ bill: sharedBill })
+      window.history.replaceState({}, '', `/b/${sharedBill.id}`)
+
+      const { result } = renderHook(() => useBill(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.state.currentBill.id).toBe(sharedBill.id)
+      })
+
+      expect(result.current.state.billSource).toBe('shared')
+      expect(getBillFromCloud).toHaveBeenCalledWith(sharedBill.id)
+    })
+
     it('should load a shared bill when the URL changes after mount', async () => {
       const sharedBill = createMockBill({
         id: '1780007206455-yojajgt',
@@ -586,6 +605,7 @@ describe('BillContext', () => {
       expect(result.current.state.currentBill.title).toBe('Edited Copy')
       expect(result.current.state.billSource).toBe('shared_copy')
       expect(result.current.state.sharedOriginBillId).toBe(sharedBill.id)
+      expect(window.location.pathname).toBe('/')
       expect(window.location.search).toBe('')
     })
 

--- a/lib/__tests__/backend-proxy.test.ts
+++ b/lib/__tests__/backend-proxy.test.ts
@@ -8,17 +8,20 @@ describe("proxyToBackend", () => {
   const originalFetch = global.fetch
   const originalBackendUrl = process.env.CLOUDFLARE_BACKEND_URL
   const originalBackendSecret = process.env.BACKEND_SHARED_SECRET
+  let consoleErrorSpy: jest.SpyInstance
 
   beforeEach(() => {
     process.env.CLOUDFLARE_BACKEND_URL = "https://splitsimple-backend.aarekaz.workers.dev"
     process.env.BACKEND_SHARED_SECRET = "test-secret"
     global.fetch = jest.fn()
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
   })
 
   afterEach(() => {
     global.fetch = originalFetch
     process.env.CLOUDFLARE_BACKEND_URL = originalBackendUrl
     process.env.BACKEND_SHARED_SECRET = originalBackendSecret
+    consoleErrorSpy.mockRestore()
     jest.clearAllMocks()
   })
 
@@ -57,5 +60,15 @@ describe("proxyToBackend", () => {
     expect(String(url)).toBe("https://splitsimple-backend.aarekaz.workers.dev/api/bills/bill-123?view=full")
     expect(init.headers.get("x-splitsimple-backend-secret")).toBe("test-secret")
     expect(init.headers.get("x-splitsimple-public-url")).toBe("https://splitsimple.anuragd.me")
+  })
+
+  it("returns a readable 502 when the backend fetch fails", async () => {
+    ;(global.fetch as jest.Mock).mockRejectedValue(new TypeError("fetch failed"))
+
+    const request = new NextRequest("https://splitsimple.anuragd.me/api/bills/bill-123")
+    const response = await proxyToBackend(request, "/api/bills/bill-123")
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toEqual({ error: "Backend service is unavailable" })
   })
 })

--- a/lib/__tests__/persisted-bill.test.ts
+++ b/lib/__tests__/persisted-bill.test.ts
@@ -1,0 +1,35 @@
+import { normalizeBillForPersistence } from "@/lib/persisted-bill"
+import { createMockBill, createMockItem } from "../../tests/utils/test-utils"
+
+describe("normalizeBillForPersistence", () => {
+  it("removes empty seeded rows before saving", () => {
+    const bill = createMockBill({
+      title: "  Team Lunch  ",
+      notes: "  Remember dessert  ",
+      items: [
+        createMockItem({ name: "", price: "", quantity: 1, splitWith: [] }),
+        createMockItem({ name: "Tacos", price: "12.34", quantity: 1, splitWith: [] }),
+      ],
+    })
+
+    const normalized = normalizeBillForPersistence(bill)
+
+    expect(normalized.title).toBe("Team Lunch")
+    expect(normalized.notes).toBe("Remember dessert")
+    expect(normalized.items).toHaveLength(1)
+    expect(normalized.items[0].name).toBe("Tacos")
+  })
+
+  it("keeps partially filled rows that have meaningful content", () => {
+    const bill = createMockBill({
+      items: [
+        createMockItem({ name: "", price: "5.00", quantity: 1, splitWith: [] }),
+      ],
+    })
+
+    const normalized = normalizeBillForPersistence(bill)
+
+    expect(normalized.items).toHaveLength(1)
+    expect(normalized.items[0].price).toBe("5.00")
+  })
+})

--- a/lib/__tests__/sharing.test.ts
+++ b/lib/__tests__/sharing.test.ts
@@ -1,4 +1,4 @@
-import { extractBillIdFromInput } from '@/lib/sharing'
+import { extractBillIdFromInput, getSharedBillIdFromSearch, stripSharedBillParams } from '@/lib/sharing'
 
 describe('extractBillIdFromInput', () => {
   it('returns a raw bill ID unchanged', () => {
@@ -13,5 +13,16 @@ describe('extractBillIdFromInput', () => {
 
   it('extracts the bill ID from a query string fragment', () => {
     expect(extractBillIdFromInput('?bill=1780007206455-yojajgt')).toBe('1780007206455-yojajgt')
+  })
+})
+
+describe('shared bill search helpers', () => {
+  it('reads the shared bill id from search params', () => {
+    expect(getSharedBillIdFromSearch('?bill=1780007206455-yojajgt&view=breakdown')).toBe('1780007206455-yojajgt')
+  })
+
+  it('clears shared bill params while preserving unrelated params', () => {
+    expect(stripSharedBillParams('bill=1780007206455-yojajgt&view=breakdown')).toBe('?view=breakdown')
+    expect(stripSharedBillParams('?share=1780007206455-yojajgt')).toBe('')
   })
 })

--- a/lib/__tests__/sharing.test.ts
+++ b/lib/__tests__/sharing.test.ts
@@ -1,4 +1,12 @@
-import { extractBillIdFromInput, getSharedBillIdFromSearch, stripSharedBillParams } from '@/lib/sharing'
+import {
+  buildSharedBillPath,
+  extractBillIdFromInput,
+  getSharedBillIdFromLocationParts,
+  getSharedBillIdFromPathname,
+  getSharedBillIdFromSearch,
+  stripSharedBillLocation,
+  stripSharedBillParams,
+} from '@/lib/sharing'
 
 describe('extractBillIdFromInput', () => {
   it('returns a raw bill ID unchanged', () => {
@@ -8,6 +16,12 @@ describe('extractBillIdFromInput', () => {
   it('extracts the bill ID from a full share URL', () => {
     expect(
       extractBillIdFromInput('https://splitsimple.anuragd.me/?bill=1780007206455-yojajgt')
+    ).toBe('1780007206455-yojajgt')
+  })
+
+  it('extracts the bill ID from the dedicated shared route', () => {
+    expect(
+      extractBillIdFromInput('https://splitsimple.anuragd.me/b/1780007206455-yojajgt')
     ).toBe('1780007206455-yojajgt')
   })
 
@@ -21,8 +35,21 @@ describe('shared bill search helpers', () => {
     expect(getSharedBillIdFromSearch('?bill=1780007206455-yojajgt&view=breakdown')).toBe('1780007206455-yojajgt')
   })
 
+  it('reads the shared bill id from the dedicated shared path', () => {
+    expect(getSharedBillIdFromPathname('/b/1780007206455-yojajgt')).toBe('1780007206455-yojajgt')
+    expect(getSharedBillIdFromLocationParts('/b/1780007206455-yojajgt', '?view=breakdown')).toBe('1780007206455-yojajgt')
+  })
+
   it('clears shared bill params while preserving unrelated params', () => {
     expect(stripSharedBillParams('bill=1780007206455-yojajgt&view=breakdown')).toBe('?view=breakdown')
     expect(stripSharedBillParams('?share=1780007206455-yojajgt')).toBe('')
+  })
+
+  it('strips shared bill route state back to the draft workspace', () => {
+    expect(stripSharedBillLocation('/b/1780007206455-yojajgt', '?view=breakdown')).toBe('/?view=breakdown')
+  })
+
+  it('builds the dedicated shared bill path', () => {
+    expect(buildSharedBillPath('1780007206455-yojajgt')).toBe('/b/1780007206455-yojajgt')
   })
 })

--- a/lib/backend-proxy.ts
+++ b/lib/backend-proxy.ts
@@ -55,7 +55,17 @@ export async function proxyToBackend(
     method: request.method,
     headers,
     body,
+  }).catch((error: unknown) => {
+    console.error("Backend proxy request failed:", error)
+    return null
   })
+
+  if (!backendResponse) {
+    return NextResponse.json(
+      { error: "Backend service is unavailable" },
+      { status: 502 }
+    )
+  }
 
   return new NextResponse(backendResponse.body, {
     status: backendResponse.status,

--- a/lib/bill-types.ts
+++ b/lib/bill-types.ts
@@ -1,4 +1,5 @@
 export type SyncStatus = "never_synced" | "syncing" | "synced" | "error"
+export type BillSource = "draft" | "shared" | "shared_copy"
 
 export type SplitMethod = "even" | "shares" | "percent" | "exact"
 

--- a/lib/persisted-bill.ts
+++ b/lib/persisted-bill.ts
@@ -1,0 +1,26 @@
+import type { Bill, Item } from "@/lib/bill-types"
+
+function hasMeaningfulItemContent(item: Item): boolean {
+  return (
+    item.name.trim() !== "" ||
+    item.price.trim() !== "" ||
+    item.quantity !== 1 ||
+    item.splitWith.length > 0 ||
+    Object.keys(item.customSplits ?? {}).length > 0
+  )
+}
+
+export function normalizeBillForPersistence(bill: Bill): Bill {
+  return {
+    ...bill,
+    title: bill.title.trim() || "New Bill",
+    notes: bill.notes.trim(),
+    items: bill.items
+      .filter(hasMeaningfulItemContent)
+      .map((item) => ({
+        ...item,
+        name: item.name.trim(),
+        price: item.price.trim(),
+      })),
+  }
+}

--- a/lib/sharing.ts
+++ b/lib/sharing.ts
@@ -1,4 +1,5 @@
 import type { Bill, CloudBillResult, CloudStoreResult } from "@/lib/bill-types"
+import { normalizeBillForPersistence } from "@/lib/persisted-bill"
 import { isMigratableBill, isRecord, migrateBillSchema } from "@/lib/validation"
 
 const FULL_BILL_ID_PATTERN = /^\d{13}-[a-z0-9]+$/i
@@ -58,7 +59,7 @@ export async function storeBillInCloud(bill: Bill): Promise<CloudStoreResult> {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ bill }),
+      body: JSON.stringify({ bill: normalizeBillForPersistence(bill) }),
     })
 
     if (!response.ok) {

--- a/lib/sharing.ts
+++ b/lib/sharing.ts
@@ -3,14 +3,29 @@ import { normalizeBillForPersistence } from "@/lib/persisted-bill"
 import { isMigratableBill, isRecord, migrateBillSchema } from "@/lib/validation"
 
 const FULL_BILL_ID_PATTERN = /^\d{13}-[a-z0-9]+$/i
+const SHARED_BILL_PATH_PATTERN = /^\/b\/([^/?#]+)\/?$/
 
 function normalizeSearchInput(search: string): string {
   return search.startsWith("?") ? search.slice(1) : search
 }
 
+function normalizeSearchOutput(search: string): string {
+  if (!search) return ""
+  return search.startsWith("?") ? search : `?${search}`
+}
+
 export function getSharedBillIdFromSearch(search: string): string | null {
   const params = new URLSearchParams(normalizeSearchInput(search))
   return params.get("bill") || params.get("share")
+}
+
+export function getSharedBillIdFromPathname(pathname: string): string | null {
+  const match = pathname.match(SHARED_BILL_PATH_PATTERN)
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+export function getSharedBillIdFromLocationParts(pathname: string, search: string): string | null {
+  return getSharedBillIdFromPathname(pathname) || getSharedBillIdFromSearch(search)
 }
 
 export function stripSharedBillParams(search: string): string {
@@ -20,6 +35,20 @@ export function stripSharedBillParams(search: string): string {
 
   const nextSearch = params.toString()
   return nextSearch ? `?${nextSearch}` : ""
+}
+
+export function buildSharedBillPath(billId: string): string {
+  return `/b/${encodeURIComponent(billId)}`
+}
+
+export function buildAppUrl(pathname: string, search = "", hash = ""): string {
+  return `${pathname}${normalizeSearchOutput(search)}${hash}`
+}
+
+export function stripSharedBillLocation(pathname: string, search: string, hash = ""): string {
+  const nextPathname = getSharedBillIdFromPathname(pathname) ? "/" : pathname
+  const nextSearch = stripSharedBillParams(search)
+  return buildAppUrl(nextPathname, nextSearch, hash)
 }
 
 export function extractBillIdFromInput(input: string): string {
@@ -38,11 +67,21 @@ export function extractBillIdFromInput(input: string): string {
     }
   }
 
+  const pathnameBillId = getSharedBillIdFromPathname(trimmed)
+  if (pathnameBillId) {
+    return pathnameBillId
+  }
+
   try {
     const url = new URL(trimmed)
     const sharedId = getSharedBillIdFromSearch(url.search)
     if (sharedId) {
       return sharedId.trim()
+    }
+
+    const pathId = getSharedBillIdFromPathname(url.pathname)
+    if (pathId) {
+      return pathId.trim()
     }
   } catch {
     // Fall through to raw input so callers can show the right validation error.
@@ -157,7 +196,6 @@ export async function getBillFromCloud(billId: string): Promise<CloudBillResult>
 
 // Generate shareable URL
 export function generateCloudShareUrl(billId: string): string {
-  // Ensure we always use the root path for sharing
   const baseUrl = typeof window !== 'undefined' ? window.location.origin : ''
-  return `${baseUrl}/?bill=${billId}`
+  return `${baseUrl}${buildSharedBillPath(billId)}`
 }

--- a/lib/sharing.ts
+++ b/lib/sharing.ts
@@ -3,6 +3,24 @@ import { isMigratableBill, isRecord, migrateBillSchema } from "@/lib/validation"
 
 const FULL_BILL_ID_PATTERN = /^\d{13}-[a-z0-9]+$/i
 
+function normalizeSearchInput(search: string): string {
+  return search.startsWith("?") ? search.slice(1) : search
+}
+
+export function getSharedBillIdFromSearch(search: string): string | null {
+  const params = new URLSearchParams(normalizeSearchInput(search))
+  return params.get("bill") || params.get("share")
+}
+
+export function stripSharedBillParams(search: string): string {
+  const params = new URLSearchParams(normalizeSearchInput(search))
+  params.delete("bill")
+  params.delete("share")
+
+  const nextSearch = params.toString()
+  return nextSearch ? `?${nextSearch}` : ""
+}
+
 export function extractBillIdFromInput(input: string): string {
   const trimmed = input.trim().replace(/^#/, "")
   if (!trimmed) return ""
@@ -13,8 +31,7 @@ export function extractBillIdFromInput(input: string): string {
 
   const queryStart = trimmed.indexOf("?")
   if (queryStart >= 0) {
-    const params = new URLSearchParams(trimmed.slice(queryStart + 1))
-    const sharedId = params.get("bill") || params.get("share")
+    const sharedId = getSharedBillIdFromSearch(trimmed.slice(queryStart))
     if (sharedId) {
       return sharedId.trim()
     }
@@ -22,7 +39,7 @@ export function extractBillIdFromInput(input: string): string {
 
   try {
     const url = new URL(trimmed)
-    const sharedId = url.searchParams.get("bill") || url.searchParams.get("share")
+    const sharedId = getSharedBillIdFromSearch(url.search)
     if (sharedId) {
       return sharedId.trim()
     }


### PR DESCRIPTION
## Summary
- extract shared bill query helpers and make shared reloads depend on actual bill id changes
- clear shared bill params when starting a new draft and return readable backend proxy failures
- add explicit shared vs draft bill source modes, fork shared bills into local copies on edit, and keep shared views out of draft persistence
- show shared bill mode in the header and expand regression coverage around shared bill transitions

## Testing
- pnpm test --runInBand
- pnpm typecheck
- pnpm build
