### PR TITLE
Improve shared bill flows and add non-scan bill entry paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ public/mockServiceWorker.js
 
 
 .env.local
+.claude/settings.local.json
+.gstack/
+
+# Local tooling artifacts
+.playwright-cli/

--- a/app/admin/__tests__/page.test.tsx
+++ b/app/admin/__tests__/page.test.tsx
@@ -1,0 +1,176 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@/tests/utils/test-utils'
+import AdminPage from '@/app/admin/page'
+import type { AdminBillMetadata, AdminStats, Bill } from '@/lib/bill-types'
+
+const mockToast = jest.fn()
+const mockPush = jest.fn()
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}))
+
+function createBill(overrides: Partial<Bill> = {}): Bill {
+  return {
+    id: 'bill-1',
+    title: 'Weekly Dinner',
+    status: 'active',
+    tax: '0',
+    tip: '0',
+    discount: '0',
+    taxTipAllocation: 'proportional',
+    notes: '',
+    people: [],
+    items: [],
+    ...overrides,
+  }
+}
+
+function createAdminStats(overrides: Partial<AdminStats> = {}): AdminStats {
+  return {
+    totalBills: 1,
+    activeBills: 1,
+    draftBills: 0,
+    closedBills: 0,
+    totalItems: 2,
+    totalPeople: 3,
+    totalStorageSize: 1024,
+    averageBillSize: 1024,
+    totalMoneyProcessed: 24,
+    averageBillValue: 24,
+    medianBillValue: 24,
+    largestBill: 24,
+    smallestBill: 24,
+    subtotalRevenue: 24,
+    taxRevenue: 0,
+    tipRevenue: 0,
+    totalTaxCollected: 0,
+    totalTipsProcessed: 0,
+    totalDiscountsApplied: 0,
+    billsWithTax: 0,
+    billsWithTips: 0,
+    billsWithDiscounts: 0,
+    billsCreatedToday: 1,
+    billsCreatedThisWeek: 1,
+    billsCreatedThisMonth: 1,
+    billsCreatedLastWeek: 0,
+    billsCreatedLastMonth: 0,
+    weeklyGrowth: 100,
+    monthlyGrowth: 100,
+    completionRate: 100,
+    shareRate: 100,
+    averageAccessCount: 1,
+    sharedBills: 1,
+    completedBills: 1,
+    averageItemsPerBill: 2,
+    averagePeoplePerBill: 3,
+    complexBills: 0,
+    largeBills: 0,
+    popularSplitMethods: [{ method: 'even', count: 1, percentage: 100 }],
+    ...overrides,
+  }
+}
+
+function createAdminBill(overrides: Partial<AdminBillMetadata> = {}): AdminBillMetadata {
+  return {
+    id: 'bill-1',
+    bill: createBill(),
+    createdAt: '2026-05-29T00:00:00.000Z',
+    lastModified: '2026-05-29T00:00:00.000Z',
+    expiresAt: '2027-05-29T00:00:00.000Z',
+    accessCount: 1,
+    size: 512,
+    shareUrl: 'https://splitsimple.example/b/bill-1',
+    totalAmount: 24,
+    lastAccessed: '2026-05-29T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function createBillsResponse(overrides: Partial<{ bills: AdminBillMetadata[]; stats: AdminStats; pagination: { totalPages: number } }> = {}) {
+  return {
+    bills: [createAdminBill()],
+    stats: createAdminStats(),
+    pagination: { totalPages: 1 },
+    ...overrides,
+  }
+}
+
+function createFetchResponse(status: number, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    blob: jest.fn().mockResolvedValue(new Blob()),
+  } as unknown as Response
+}
+
+describe('AdminPage', () => {
+  beforeEach(() => {
+    mockToast.mockReset()
+    mockPush.mockReset()
+    global.fetch = jest.fn()
+  })
+
+  it('returns to the login screen when the admin session expires during bill fetch', async () => {
+    jest.mocked(global.fetch)
+      .mockResolvedValueOnce(createFetchResponse(200))
+      .mockResolvedValueOnce(createFetchResponse(401, { error: 'Unauthorized' }))
+
+    render(<AdminPage />)
+
+    expect(await screen.findByText('Admin Access')).toBeInTheDocument()
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Session expired',
+      })
+    )
+  })
+
+  it('shows an empty state instead of a blank table when no bills are returned', async () => {
+    jest.mocked(global.fetch)
+      .mockResolvedValueOnce(createFetchResponse(200))
+      .mockResolvedValueOnce(
+        createFetchResponse(200, createBillsResponse({ bills: [], stats: createAdminStats({ totalBills: 0, activeBills: 0, sharedBills: 0, totalItems: 0, totalPeople: 0, totalMoneyProcessed: 0, averageBillValue: 0, medianBillValue: 0, largestBill: 0, smallestBill: 0, subtotalRevenue: 0, averageBillSize: 0, averageAccessCount: 0, completionRate: 0, shareRate: 0, averageItemsPerBill: 0, averagePeoplePerBill: 0, completedBills: 0 }), pagination: { totalPages: 0 } }))
+      )
+
+    render(<AdminPage />)
+
+    expect(await screen.findByText(/no bills found/i)).toBeInTheDocument()
+    expect(screen.getByText(/try changing your search or filters/i)).toBeInTheDocument()
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument()
+  })
+
+  it('requests a supported backend sort key when sorting by total amount', async () => {
+    const user = userEvent.setup()
+
+    jest.mocked(global.fetch)
+      .mockResolvedValueOnce(createFetchResponse(200))
+      .mockResolvedValueOnce(createFetchResponse(200, createBillsResponse()))
+      .mockResolvedValueOnce(createFetchResponse(200, createBillsResponse()))
+
+    render(<AdminPage />)
+
+    await screen.findByText('Bills Command Center')
+
+    await user.selectOptions(screen.getByLabelText(/sort by/i), 'total')
+
+    await waitFor(() => {
+      const lastCallUrl = jest.mocked(global.fetch).mock.calls.at(-1)?.[0]
+      expect(lastCallUrl).toEqual(expect.stringContaining('sortBy=total'))
+    })
+  })
+})

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -130,6 +130,10 @@ export default function AdminPage() {
       fetchAbortRef.current = null
     }
 
+    // The abort above clears fetchAbortRef, so the in-flight fetchBills' finally
+    // guard (fetchAbortRef.current === controller) will skip its own cleanup.
+    // Reset the loading flag here as part of the unauthorized teardown.
+    setIsFetching(false)
     setIsAuthenticated(false)
     setBills([])
     setStats(null)

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -87,11 +87,16 @@ interface AdminBillsResponse {
   }
 }
 
+interface ApiErrorResponse {
+  error?: string
+}
+
 export default function AdminPage() {
   const router = useRouter()
   const { toast } = useToast()
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
+  const [isFetching, setIsFetching] = useState(false)
   const [password, setPassword] = useState('')
   const [bills, setBills] = useState<AdminBillMetadata[]>([])
   const [stats, setStats] = useState<AdminStats | null>(null)
@@ -107,6 +112,37 @@ export default function AdminPage() {
   const [billToDelete, setBillToDelete] = useState<string | null>(null)
   const fetchDebounceRef = useRef<number | null>(null)
   const fetchAbortRef = useRef<AbortController | null>(null)
+
+  const readErrorMessage = async (response: Response, fallback: string) => {
+    try {
+      const data = await response.json() as ApiErrorResponse
+      return data.error || fallback
+    } catch {
+      return fallback
+    }
+  }
+
+  const handleUnauthorized = () => {
+    if (!isAuthenticated) return
+
+    if (fetchAbortRef.current) {
+      fetchAbortRef.current.abort()
+      fetchAbortRef.current = null
+    }
+
+    setIsAuthenticated(false)
+    setBills([])
+    setStats(null)
+    setSelectedBill(null)
+    setShowBillDialog(false)
+    setShowDeleteDialog(false)
+    setBillToDelete(null)
+    toast({
+      title: 'Session expired',
+      description: 'Please log in again to continue managing bills.',
+      variant: 'destructive'
+    })
+  }
 
   useEffect(() => {
     checkAuth()
@@ -130,6 +166,17 @@ export default function AdminPage() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, currentPage, searchQuery, statusFilter, sortBy, sortOrder])
+
+  useEffect(() => {
+    return () => {
+      if (fetchAbortRef.current) {
+        fetchAbortRef.current.abort()
+      }
+      if (fetchDebounceRef.current) {
+        window.clearTimeout(fetchDebounceRef.current)
+      }
+    }
+  }, [])
 
   const checkAuth = async () => {
     try {
@@ -190,6 +237,7 @@ export default function AdminPage() {
 
   const fetchBills = async () => {
     try {
+      setIsFetching(true)
       if (fetchAbortRef.current) {
         fetchAbortRef.current.abort()
       }
@@ -209,12 +257,27 @@ export default function AdminPage() {
         signal: controller.signal
       })
 
-      if (response.ok) {
-        const data = await response.json() as AdminBillsResponse
-        setBills(data.bills)
-        setStats(data.stats)
-        setTotalPages(data.pagination.totalPages)
+      if (response.status === 401) {
+        handleUnauthorized()
+        return
       }
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, 'Failed to fetch bills'))
+      }
+
+      const data = await response.json() as AdminBillsResponse
+      const safeTotalPages = Math.max(1, data.pagination.totalPages || 1)
+
+      if (currentPage > safeTotalPages) {
+        setTotalPages(safeTotalPages)
+        setCurrentPage(safeTotalPages)
+        return
+      }
+
+      setBills(data.bills)
+      setStats(data.stats)
+      setTotalPages(safeTotalPages)
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
         return
@@ -222,9 +285,12 @@ export default function AdminPage() {
       console.error('Error fetching bills:', error)
       toast({
         title: 'Error',
-        description: 'Failed to fetch bills',
+        description: error instanceof Error ? error.message : 'Failed to fetch bills',
         variant: 'destructive'
       })
+    } finally {
+      setIsFetching(false)
+      fetchAbortRef.current = null
     }
   }
 
@@ -234,25 +300,30 @@ export default function AdminPage() {
         method: 'DELETE'
       })
 
-      if (response.ok) {
-        toast({
-          title: 'Success',
-          description: 'Bill deleted successfully'
-        })
-        fetchBills()
-      } else {
-        throw new Error('Failed to delete bill')
+      if (response.status === 401) {
+        handleUnauthorized()
+        return
       }
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, 'Failed to delete bill'))
+      }
+
+      toast({
+        title: 'Success',
+        description: 'Bill deleted successfully'
+      })
+      await fetchBills()
     } catch (error) {
       toast({
         title: 'Error',
-        description: 'Failed to delete bill',
+        description: error instanceof Error ? error.message : 'Failed to delete bill',
         variant: 'destructive'
       })
+    } finally {
+      setShowDeleteDialog(false)
+      setBillToDelete(null)
     }
-
-    setShowDeleteDialog(false)
-    setBillToDelete(null)
   }
 
   const handleExtendBill = async (billId: string, days: number = 30) => {
@@ -263,19 +334,24 @@ export default function AdminPage() {
         body: JSON.stringify({ days })
       })
 
-      if (response.ok) {
-        toast({
-          title: 'Success',
-          description: `Bill expiration extended by ${days} days`
-        })
-        fetchBills()
-      } else {
-        throw new Error('Failed to extend bill')
+      if (response.status === 401) {
+        handleUnauthorized()
+        return
       }
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, 'Failed to extend bill expiration'))
+      }
+
+      toast({
+        title: 'Success',
+        description: `Bill expiration extended by ${days} days`
+      })
+      await fetchBills()
     } catch (error) {
       toast({
         title: 'Error',
-        description: 'Failed to extend bill expiration',
+        description: error instanceof Error ? error.message : 'Failed to extend bill expiration',
         variant: 'destructive'
       })
     }
@@ -285,39 +361,52 @@ export default function AdminPage() {
     try {
       const response = await fetch(`/api/admin/export?format=${format}`)
 
-      if (response.ok) {
-        const blob = await response.blob()
-        const url = window.URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = `bills_export_${new Date().toISOString()}.${format}`
-        document.body.appendChild(a)
-        a.click()
-        window.URL.revokeObjectURL(url)
-        document.body.removeChild(a)
-
-        toast({
-          title: 'Success',
-          description: 'Bills exported successfully'
-        })
-      } else {
-        throw new Error('Failed to export bills')
+      if (response.status === 401) {
+        handleUnauthorized()
+        return
       }
+
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, 'Failed to export bills'))
+      }
+
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `bills_export_${new Date().toISOString()}.${format}`
+      document.body.appendChild(a)
+      a.click()
+      window.URL.revokeObjectURL(url)
+      document.body.removeChild(a)
+
+      toast({
+        title: 'Success',
+        description: 'Bills exported successfully'
+      })
     } catch (error) {
       toast({
         title: 'Error',
-        description: 'Failed to export bills',
+        description: error instanceof Error ? error.message : 'Failed to export bills',
         variant: 'destructive'
       })
     }
   }
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text)
-    toast({
-      title: 'Copied',
-      description: 'Share URL copied to clipboard'
-    })
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast({
+        title: 'Copied',
+        description: 'Share URL copied to clipboard'
+      })
+    } catch {
+      toast({
+        title: 'Clipboard blocked',
+        description: 'Could not copy the share URL. Please copy it manually.',
+        variant: 'destructive'
+      })
+    }
   }
 
   const formatBytes = (bytes: number) => {
@@ -327,7 +416,8 @@ export default function AdminPage() {
   }
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString()
+    const date = new Date(dateString)
+    return Number.isNaN(date.getTime()) ? 'Unknown' : date.toLocaleString()
   }
 
   const getStatusBadge = (status: string) => {
@@ -343,6 +433,10 @@ export default function AdminPage() {
       </Badge>
     )
   }
+
+  const safeBillsTotal = Math.max(stats?.totalBills || 0, 1)
+  const activeBillsShare = stats ? Math.min(100, (stats.activeBills / safeBillsTotal) * 100) : 0
+  const sharedBillsShare = stats?.totalBills ? Math.round((stats.sharedBills / stats.totalBills) * 100) : 0
 
   if (isLoading) {
     return (
@@ -666,7 +760,7 @@ export default function AdminPage() {
                   <div className="flex items-center gap-2 mt-3">
                     <div className="flex-1 bg-green-200 rounded-full h-2">
                       <div className="bg-green-500 h-2 rounded-full transition-[width] duration-500" style={{
-                        width: `${Math.min(100, (stats.activeBills / stats.totalBills) * 100)}%`
+                        width: `${activeBillsShare}%`
                       }} />
                     </div>
                     <span className="text-xs text-green-600">of {stats.totalBills} total</span>
@@ -691,7 +785,7 @@ export default function AdminPage() {
                   
                   <div className="text-3xl font-bold text-gray-900 mb-2">{stats.sharedBills}</div>
                   <p className="text-sm text-gray-600">
-                    {Math.round((stats.sharedBills / stats.totalBills) * 100)}% collaboration rate
+                    {sharedBillsShare}% collaboration rate
                   </p>
                 </CardContent>
               </Card>
@@ -726,10 +820,11 @@ export default function AdminPage() {
                   onClick={() => fetchBills()} 
                   variant="outline" 
                   size="sm"
+                  disabled={isFetching}
                   className="gap-1 btn-smooth border-slate-200 hover:border-slate-300"
                 >
-                  <RefreshCw className="h-4 w-4" />
-                  Sync
+                  <RefreshCw className={`h-4 w-4 ${isFetching ? 'animate-spin' : ''}`} />
+                  {isFetching ? 'Syncing…' : 'Sync'}
                 </Button>
                 
                 <div className="flex items-center">
@@ -764,7 +859,10 @@ export default function AdminPage() {
                   value={searchQuery}
                   name="search-bills"
                   autoComplete="off"
-                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onChange={(e) => {
+                    setSearchQuery(e.target.value)
+                    setCurrentPage(1)
+                  }}
                   aria-label="Search bills"
                   className="w-full pl-10 pr-4 py-2 bg-white border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
                 />
@@ -773,7 +871,10 @@ export default function AdminPage() {
               <div className="flex items-center gap-2">
                 <select
                   value={statusFilter}
-                  onChange={(e) => setStatusFilter(e.target.value)}
+                  onChange={(e) => {
+                    setStatusFilter(e.target.value)
+                    setCurrentPage(1)
+                  }}
                   aria-label="Filter by status"
                   className="px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
                 >
@@ -785,18 +886,27 @@ export default function AdminPage() {
                 
                 <select
                   value={sortBy}
-                  onChange={(e) => setSortBy(e.target.value)}
+                  onChange={(e) => {
+                    setSortBy(e.target.value)
+                    setCurrentPage(1)
+                  }}
                   aria-label="Sort by"
                   className="px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
                 >
                   <option value="lastModified">Last Modified</option>
                   <option value="createdAt">Created</option>
-                  <option value="totalAmount">Amount</option>
-                  <option value="accessCount">Access Count</option>
+                  <option value="total">Amount</option>
+                  <option value="title">Title</option>
+                  <option value="people">People</option>
+                  <option value="items">Items</option>
+                  <option value="size">Size</option>
                 </select>
                 
                 <Button
-                  onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
+                  onClick={() => {
+                    setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')
+                    setCurrentPage(1)
+                  }}
                   variant="outline"
                   size="sm"
                   className="px-2 btn-smooth border-slate-200 hover:border-slate-300"
@@ -813,6 +923,7 @@ export default function AdminPage() {
                     setStatusFilter('all')
                     setSortBy('lastModified')
                     setSortOrder('desc')
+                    setCurrentPage(1)
                   }}
                 >
                   <XCircle className="h-4 w-4" />
@@ -840,7 +951,16 @@ export default function AdminPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {bills.map((bill) => (
+                  {bills.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={9} className="py-12 text-center">
+                        <div className="space-y-2">
+                          <p className="font-medium text-slate-800">No bills found</p>
+                          <p className="text-sm text-slate-500">Try changing your search or filters, or sync again.</p>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ) : bills.map((bill) => (
                     <TableRow key={bill.id}>
                       <TableCell className="font-medium">
                         {bill.bill.title || 'Untitled'}
@@ -884,7 +1004,7 @@ export default function AdminPage() {
                           <Button
                             variant="ghost"
                             size="icon"
-                            onClick={() => copyToClipboard(bill.shareUrl)}
+                            onClick={() => void copyToClipboard(bill.shareUrl)}
                             title="Copy share link"
                             aria-label="Copy share link"
                           >
@@ -996,7 +1116,7 @@ export default function AdminPage() {
                   <Button
                     variant="outline"
                     size="icon"
-                    onClick={() => copyToClipboard(selectedBill.shareUrl)}
+                    onClick={() => void copyToClipboard(selectedBill.shareUrl)}
                     aria-label="Copy share URL"
                   >
                     <Copy className="h-4 w-4" />

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -236,13 +236,14 @@ export default function AdminPage() {
   }
 
   const fetchBills = async () => {
+    if (fetchAbortRef.current) {
+      fetchAbortRef.current.abort()
+    }
+    const controller = new AbortController()
+    fetchAbortRef.current = controller
+
     try {
       setIsFetching(true)
-      if (fetchAbortRef.current) {
-        fetchAbortRef.current.abort()
-      }
-      const controller = new AbortController()
-      fetchAbortRef.current = controller
 
       const params = new URLSearchParams({
         page: currentPage.toString(),
@@ -289,8 +290,12 @@ export default function AdminPage() {
         variant: 'destructive'
       })
     } finally {
-      setIsFetching(false)
-      fetchAbortRef.current = null
+      // Only the latest request may clear shared state; an aborted older request
+      // must not null a newer request's controller or hide its loading spinner.
+      if (fetchAbortRef.current === controller) {
+        setIsFetching(false)
+        fetchAbortRef.current = null
+      }
     }
   }
 

--- a/app/b/[billId]/opengraph-image.tsx
+++ b/app/b/[billId]/opengraph-image.tsx
@@ -1,0 +1,81 @@
+import { ImageResponse } from "next/og"
+import { loadSharedBill } from "@/lib/load-shared-bill"
+import { buildSharedBillOgModel } from "@/lib/shared-bill-og"
+
+// Render on the Node.js runtime (Fluid Compute), not the Edge runtime.
+export const runtime = "nodejs"
+// Regenerate at most every 5 minutes so edits surface without hammering the
+// backend on every social-scraper request. Route-segment config must be a
+// static literal, so this mirrors SHARED_BILL_REVALIDATE_SECONDS by value.
+export const revalidate = 300
+
+export const alt = "Shared bill on SplitSimple"
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+
+interface CardFields {
+  title: string
+  meta: string | null
+  footer: string
+}
+
+function OgCard({ title, meta, footer }: CardFields) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "72px",
+        backgroundColor: "#0F172A",
+        backgroundImage:
+          "radial-gradient(900px 450px at 100% 0%, rgba(79,70,229,0.35), rgba(79,70,229,0) 60%), radial-gradient(700px 400px at 0% 100%, rgba(16,185,129,0.22), rgba(16,185,129,0) 60%)",
+        color: "#F8FAFC",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "14px" }}>
+        <div style={{ width: "16px", height: "16px", borderRadius: "9999px", backgroundColor: "#16A34A" }} />
+        <div style={{ fontSize: "24px", letterSpacing: "6px", color: "#94A3B8", fontWeight: 600 }}>
+          SPLITSIMPLE · SHARED BILL
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+        <div style={{ fontSize: "76px", fontWeight: 800, lineHeight: 1.05, color: "#FFFFFF" }}>{title}</div>
+        {meta ? (
+          <div style={{ fontSize: "36px", fontWeight: 600, color: "#C7D2FE" }}>{meta}</div>
+        ) : null}
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end" }}>
+        <div style={{ fontSize: "28px", color: "#E2E8F0", fontWeight: 600 }}>{footer}</div>
+        <div style={{ fontSize: "24px", color: "#64748B" }}>splitsimple.anuragd.me</div>
+      </div>
+    </div>
+  )
+}
+
+export default async function Image({ params }: { params: Promise<{ billId: string }> }) {
+  const { billId } = await params
+  const bill = await loadSharedBill(billId)
+
+  const fields: CardFields = bill
+    ? (() => {
+        const model = buildSharedBillOgModel(bill)
+        return {
+          title: model.title,
+          meta: `${model.peopleLabel} · ${model.totalLabel} total`,
+          footer: "Tap to view your share →",
+        }
+      })()
+    : {
+        title: "Split bills in seconds.",
+        meta: null,
+        footer: "Open to split this bill →",
+      }
+
+  return new ImageResponse(<OgCard {...fields} />, { ...size })
+}

--- a/app/b/[billId]/page.tsx
+++ b/app/b/[billId]/page.tsx
@@ -13,8 +13,14 @@ interface SharedBillPageProps {
 // description, falling back to generic copy when the bill can't be loaded.
 export async function generateMetadata({ params }: SharedBillPageProps): Promise<Metadata> {
   const { billId } = await params
+
+  // Shared bills are random-ID utility pages that carry user financial data and
+  // near-identical structure — never index them. Social scrapers ignore robots,
+  // so the rich OG preview still works.
+  const noindex = { index: false, follow: false } as const
+
   const bill = await loadSharedBill(billId)
-  if (!bill) return {}
+  if (!bill) return { robots: noindex }
 
   const { title, peopleLabel, totalLabel } = buildSharedBillOgModel(bill)
   const pageTitle = `${title} · SplitSimple`
@@ -26,6 +32,7 @@ export async function generateMetadata({ params }: SharedBillPageProps): Promise
   return {
     title: pageTitle,
     description,
+    robots: noindex,
     openGraph: { title: pageTitle, description, type: "website", siteName: "SplitSimple" },
     twitter: { card: "summary_large_image", title: pageTitle, description },
   }

--- a/app/b/[billId]/page.tsx
+++ b/app/b/[billId]/page.tsx
@@ -1,5 +1,35 @@
 import { Suspense } from "react"
+import type { Metadata } from "next"
 import { ProBillSplitter } from "@/components/ProBillSplitter"
+import { loadSharedBill } from "@/lib/load-shared-bill"
+import { buildSharedBillOgModel } from "@/lib/shared-bill-og"
+
+interface SharedBillPageProps {
+  params: Promise<{ billId: string }>
+}
+
+// Reflect the shared bill's title/total in the link preview text. The colocated
+// opengraph-image route supplies the image; here we only override the title and
+// description, falling back to generic copy when the bill can't be loaded.
+export async function generateMetadata({ params }: SharedBillPageProps): Promise<Metadata> {
+  const { billId } = await params
+  const bill = await loadSharedBill(billId)
+  if (!bill) return {}
+
+  const { title, peopleLabel, totalLabel } = buildSharedBillOgModel(bill)
+  const pageTitle = `${title} · SplitSimple`
+  const description = `Split ${totalLabel} across ${peopleLabel}. Open to see your share.`
+
+  // Next.js shallow-merges metadata, so the openGraph/twitter objects replace the
+  // layout's wholesale. Restate the inherited fields we care about — notably
+  // twitter.card, so the large image card isn't downgraded to a small summary.
+  return {
+    title: pageTitle,
+    description,
+    openGraph: { title: pageTitle, description, type: "website", siteName: "SplitSimple" },
+    twitter: { card: "summary_large_image", title: pageTitle, description },
+  }
+}
 
 export default function SharedBillPage() {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,14 +9,16 @@ import { PostHogProvider } from "@/components/PostHogProvider"
 export const metadata: Metadata = {
   metadataBase: new URL("https://splitsimple.anuragd.me"),
   title: "SplitSimple - Easy Expense Splitting",
-  description: "Split expenses with friends and colleagues effortlessly",
+  description:
+    "Split restaurant bills, rent, and group expenses by item, share, or exact amount. Free with no signup — see everyone's share instantly and share a link.",
   generator: "v0.app",
   alternates: {
     canonical: "/",
   },
   openGraph: {
     title: "SplitSimple - Easy Expense Splitting",
-    description: "Split expenses with friends and colleagues effortlessly",
+    description:
+      "Split restaurant bills, rent, and group expenses by item, share, or exact amount. Free with no signup — see everyone's share instantly and share a link.",
     url: "https://splitsimple.anuragd.me",
     siteName: "SplitSimple",
     locale: "en_US",
@@ -34,7 +36,8 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "SplitSimple - Easy Expense Splitting",
-    description: "Split expenses with friends and colleagues effortlessly",
+    description:
+      "Split restaurant bills, rent, and group expenses by item, share, or exact amount. Free with no signup — see everyone's share instantly and share a link.",
     images: [
       {
         url: "/og-image.png",

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next"
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "SplitSimple - Easy Expense Splitting",
+    short_name: "SplitSimple",
+    description:
+      "Split restaurant bills, rent, and group expenses by item, share, or exact amount. Free with no signup — see everyone's share instantly and share a link.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#1E40AF",
+    icons: [
+      {
+        // Single scalable SVG icon; modern browsers accept sizes "any" for SVG.
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+      },
+    ],
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,8 +44,32 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   }
 
   return (
-    <Suspense>
-      <ProBillSplitter />
-    </Suspense>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Suspense>
+        <ProBillSplitter />
+      </Suspense>
+    </>
   )
+}
+
+// WebApplication structured data for the homepage — helps Google rich results
+// and AI answer engines understand what SplitSimple is and that it's free.
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "SplitSimple",
+  url: "https://splitsimple.anuragd.me",
+  description:
+    "Split restaurant bills, rent, and group expenses by item, share, or exact amount. Free with no signup — see everyone's share instantly and share a link.",
+  applicationCategory: "FinanceApplication",
+  operatingSystem: "Web",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next"
+
+const SITE_URL = "https://splitsimple.anuragd.me"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      // Admin is private; shared bills (/b/) hold user financial data and are
+      // intentionally noindex; API routes return no indexable content.
+      disallow: ["/admin", "/b/", "/api/", "/og-image"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next"
+
+const SITE_URL = "https://splitsimple.anuragd.me"
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Only the homepage is indexable today. Admin, /b/ shared bills, /og-image,
+  // and API routes are intentionally excluded (see robots.ts). Add new public
+  // content/landing pages here as they ship.
+  return [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ]
+}

--- a/components/BillSourceIndicator.tsx
+++ b/components/BillSourceIndicator.tsx
@@ -1,7 +1,10 @@
 "use client"
 
-import { Copy, Link2 } from "lucide-react"
+import { Copy, Link2, RotateCcw } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { useBill } from "@/contexts/BillContext"
+import { Button } from "@/components/ui/button"
+import { buildSharedBillPath } from "@/lib/sharing"
 import { cn } from "@/lib/utils"
 
 const billSourceConfig = {
@@ -12,13 +15,14 @@ const billSourceConfig = {
   },
   shared_copy: {
     icon: Copy,
-    label: "Editing local copy",
+    label: "Forked from shared bill",
     className: "text-amber-700 bg-amber-50",
   },
 } as const
 
 export function BillSourceIndicator({ className }: { className?: string }) {
   const { state } = useBill()
+  const router = useRouter()
 
   if (state.billSource === "draft") {
     return null
@@ -26,17 +30,33 @@ export function BillSourceIndicator({ className }: { className?: string }) {
 
   const config = billSourceConfig[state.billSource]
   const Icon = config.icon
+  const originalSharedBillId = state.billSource === "shared_copy" ? state.sharedOriginBillId : null
+  const canReloadOriginal = Boolean(originalSharedBillId)
 
   return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium",
-        config.className,
-        className
+    <span className={cn("inline-flex flex-wrap items-center gap-2", className)}>
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium",
+          config.className
+        )}
+      >
+        <Icon className="h-3 w-3" />
+        <span>{config.label}</span>
+      </span>
+
+      {canReloadOriginal && originalSharedBillId && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-6 rounded-full px-2 text-[11px] font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+          onClick={() => router.push(buildSharedBillPath(originalSharedBillId), { scroll: false })}
+        >
+          <RotateCcw className="mr-1 h-3 w-3" />
+          Reload original
+        </Button>
       )}
-    >
-      <Icon className="h-3 w-3" />
-      <span>{config.label}</span>
     </span>
   )
 }

--- a/components/BillStartOptions.tsx
+++ b/components/BillStartOptions.tsx
@@ -470,6 +470,12 @@ export function BillStartOptions({ className, compact = false, layout = "sidebar
                       </SelectItem>
                     </SelectContent>
                   </Select>
+                  {quickSplitMode === "exact" && (
+                    <p className="text-xs text-muted-foreground">
+                      Exact amounts should add up to the amount to split, before tax and tip. Any tax,
+                      tip, or discount is then shared proportionally on top.
+                    </p>
+                  )}
                 </div>
 
                 <div className="space-y-3">

--- a/components/BillStartOptions.tsx
+++ b/components/BillStartOptions.tsx
@@ -1,0 +1,612 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Camera, FileText, PencilLine, ArrowRight, Calculator, Percent, Scale, DollarSign, Plus, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { ReceiptScanner } from "@/components/ReceiptScanner"
+import { buildManualItemizedBill, buildQuickSplitBill, type QuickSplitMode } from "@/lib/bill-start"
+import { useBill } from "@/contexts/BillContext"
+import type { Item, ReceiptLineItem } from "@/lib/bill-types"
+import { useToast } from "@/hooks/use-toast"
+import { useBillAnalytics } from "@/hooks/use-analytics"
+import { cn } from "@/lib/utils"
+
+interface BillStartOptionsProps {
+  className?: string
+  compact?: boolean
+  layout?: "sidebar" | "grid"
+}
+
+interface QuickSplitParticipantDraft {
+  id: string
+  name: string
+  shares: string
+  exactAmount: string
+}
+
+function createParticipantDraft(index: number): QuickSplitParticipantDraft {
+  return {
+    id: `participant-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 6)}`,
+    name: "",
+    shares: "1",
+    exactAmount: "",
+  }
+}
+
+function parseCurrencyValue(value: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return 0
+  const parsed = Number.parseFloat(trimmed)
+  return Number.isFinite(parsed) ? parsed : NaN
+}
+
+export function BillStartOptions({ className, compact = false, layout = "sidebar" }: BillStartOptionsProps) {
+  const { state, dispatch } = useBill()
+  const { toast } = useToast()
+  const analytics = useBillAnalytics()
+  const [manualOpen, setManualOpen] = useState(false)
+  const [manualMode, setManualMode] = useState<"menu" | "quick">("menu")
+  const [manualTitle, setManualTitle] = useState("Manual Split")
+  const [quickTitle, setQuickTitle] = useState("Quick Split")
+  const [quickAmount, setQuickAmount] = useState("")
+  const [quickTax, setQuickTax] = useState("")
+  const [quickTip, setQuickTip] = useState("")
+  const [quickDiscount, setQuickDiscount] = useState("")
+  const [quickSplitMode, setQuickSplitMode] = useState<QuickSplitMode>("even")
+  const [participants, setParticipants] = useState<QuickSplitParticipantDraft[]>([
+    createParticipantDraft(0),
+    createParticipantDraft(1),
+  ])
+
+  const handleScanImport = (items: ReceiptLineItem[]) => {
+    items.forEach((item) => {
+      const newItem: Omit<Item, "id"> = {
+        ...item,
+        splitWith: state.currentBill.people.map((person) => person.id),
+        method: "even",
+      }
+      dispatch({ type: "ADD_ITEM", payload: newItem })
+    })
+
+    analytics.trackFeatureUsed("start_flow_receipt_import", { count: items.length })
+  }
+
+  const resetManualFlow = () => {
+    setManualMode("menu")
+    setManualTitle("Manual Split")
+    setQuickTitle("Quick Split")
+    setQuickAmount("")
+    setQuickTax("")
+    setQuickTip("")
+    setQuickDiscount("")
+    setQuickSplitMode("even")
+    setParticipants([createParticipantDraft(0), createParticipantDraft(1)])
+  }
+
+  const namedParticipants = useMemo(
+    () => participants.filter((participant) => participant.name.trim().length > 0),
+    [participants]
+  )
+
+  const quickAmountValue = parseCurrencyValue(quickAmount)
+  const quickTaxValue = parseCurrencyValue(quickTax)
+  const quickTipValue = parseCurrencyValue(quickTip)
+  const quickDiscountValue = parseCurrencyValue(quickDiscount)
+
+  const exactMismatch = useMemo(() => {
+    if (quickSplitMode !== "exact" || !Number.isFinite(quickAmountValue)) {
+      return null
+    }
+
+    const exactTotal = namedParticipants.reduce((sum, participant) => {
+      const amount = parseCurrencyValue(participant.exactAmount)
+      return sum + (Number.isFinite(amount) ? amount : 0)
+    }, 0)
+
+    const difference = Math.round((exactTotal - quickAmountValue) * 100) / 100
+    return Math.abs(difference) <= 0.01 ? null : difference
+  }, [namedParticipants, quickAmountValue, quickSplitMode])
+
+  const quickSplitError = useMemo(() => {
+    if (namedParticipants.length < 2) {
+      return "Add at least 2 people for a quick split."
+    }
+
+    if (!quickAmount.trim()) {
+      return "Enter the amount you want to split."
+    }
+
+    if (!Number.isFinite(quickAmountValue) || quickAmountValue <= 0) {
+      return "Enter a valid amount greater than 0."
+    }
+
+    if ([quickTaxValue, quickTipValue, quickDiscountValue].some((value) => Number.isNaN(value))) {
+      return "Use valid numbers for tax, tip, and discount."
+    }
+
+    if (quickSplitMode === "shares") {
+      const hasInvalidShare = namedParticipants.some((participant) => {
+        const shareValue = parseCurrencyValue(participant.shares)
+        return !Number.isFinite(shareValue) || shareValue <= 0
+      })
+
+      if (hasInvalidShare) {
+        return "Every person needs a positive share value."
+      }
+    }
+
+    if (quickSplitMode === "exact") {
+      const hasInvalidAmount = namedParticipants.some((participant) => {
+        const exactAmount = parseCurrencyValue(participant.exactAmount)
+        return !Number.isFinite(exactAmount) || exactAmount < 0
+      })
+
+      if (hasInvalidAmount) {
+        return "Every person needs a valid exact amount."
+      }
+
+      if (exactMismatch !== null) {
+        return "Exact amounts must add up to the amount being split."
+      }
+    }
+
+    return null
+  }, [
+    exactMismatch,
+    namedParticipants,
+    quickAmount,
+    quickAmountValue,
+    quickDiscountValue,
+    quickSplitMode,
+    quickTaxValue,
+    quickTipValue,
+  ])
+
+  const startManualItemized = () => {
+    dispatch({
+      type: "LOAD_BILL",
+      payload: {
+        bill: buildManualItemizedBill(manualTitle),
+        source: "draft",
+      },
+    })
+    analytics.trackFeatureUsed("start_manual_itemized")
+    toast({
+      title: "Manual bill ready",
+      description: "We added a starter person and 3 blank rows so you can type right away.",
+      variant: "success",
+    })
+    setManualOpen(false)
+    resetManualFlow()
+  }
+
+  const startQuickSplit = () => {
+    if (quickSplitError) return
+
+    dispatch({
+      type: "LOAD_BILL",
+      payload: {
+        bill: buildQuickSplitBill({
+          title: quickTitle,
+          amount: quickAmountValue,
+          tax: quickTaxValue,
+          tip: quickTipValue,
+          discount: quickDiscountValue,
+          splitMode: quickSplitMode,
+          allocation: "proportional",
+          participants: namedParticipants.map((participant) => ({
+            name: participant.name,
+            shares: parseCurrencyValue(participant.shares),
+            exactAmount: parseCurrencyValue(participant.exactAmount),
+          })),
+        }),
+        source: "draft",
+      },
+    })
+
+    analytics.trackFeatureUsed("start_quick_split", {
+      split_mode: quickSplitMode,
+      people_count: namedParticipants.length,
+      has_adjustments: Boolean(quickTax.trim() || quickTip.trim() || quickDiscount.trim()),
+    })
+    toast({
+      title: "Quick split ready",
+      description: "You can review the totals immediately or itemize later if the group wants more precision.",
+      variant: "success",
+    })
+    setManualOpen(false)
+    resetManualFlow()
+  }
+
+  const updateParticipant = (id: string, field: keyof QuickSplitParticipantDraft, value: string) => {
+    setParticipants((current) =>
+      current.map((participant) => (participant.id === id ? { ...participant, [field]: value } : participant))
+    )
+  }
+
+  const addParticipant = () => {
+    setParticipants((current) => [...current, createParticipantDraft(current.length)])
+  }
+
+  const removeParticipant = (id: string) => {
+    setParticipants((current) => (current.length > 2 ? current.filter((participant) => participant.id !== id) : current))
+  }
+
+  return (
+    <>
+      <div className={cn("space-y-3", className)}>
+        <p className="text-xs text-muted-foreground">
+          No receipt needed. Start with a photo, copied order text, or a manual split.
+        </p>
+
+        <div
+          className={cn(
+            "gap-3",
+            layout === "grid"
+              ? compact
+                ? "grid grid-cols-1"
+                : "grid grid-cols-1 md:grid-cols-3"
+              : "flex flex-col"
+          )}
+        >
+          <ReceiptScanner
+            initialTab="image"
+            onImport={handleScanImport}
+            trigger={(
+              <button type="button" className="w-full text-left">
+                <StartOptionButton
+                  icon={Camera}
+                  title="Scan receipt"
+                  description="Use a photo when you have the bill in front of you."
+                  layout={layout}
+                />
+              </button>
+            )}
+          />
+
+          <ReceiptScanner
+            initialTab="text"
+            onImport={handleScanImport}
+            trigger={(
+              <button type="button" className="w-full text-left">
+                <StartOptionButton
+                  icon={FileText}
+                  title="Paste order text"
+                  description="Great for copied order summaries, notes, or chat messages."
+                  layout={layout}
+                />
+              </button>
+            )}
+          />
+
+          <button
+            type="button"
+            onClick={() => setManualOpen(true)}
+            className="w-full text-left"
+          >
+            <StartOptionButton
+              icon={PencilLine}
+              title="Enter manually"
+              description="Type items yourself or build a quick split without a receipt."
+              layout={layout}
+            />
+          </button>
+        </div>
+      </div>
+
+      <Dialog
+        open={manualOpen}
+        onOpenChange={(open) => {
+          setManualOpen(open)
+          if (!open) {
+            resetManualFlow()
+          }
+        }}
+      >
+        <DialogContent className="max-w-[95vw] sm:max-w-2xl">
+          {manualMode === "menu" ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>Enter Manually</DialogTitle>
+                <DialogDescription>
+                  Choose the fastest path for the information you have right now.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="grid gap-3 md:grid-cols-2">
+                <button
+                  type="button"
+                  onClick={() => setManualMode("quick")}
+                  className="rounded-2xl border border-border bg-slate-50 p-5 text-left transition-colors hover:border-primary/50 hover:bg-primary/5"
+                >
+                  <div className="mb-3 inline-flex rounded-xl bg-white p-2 shadow-sm">
+                    <Calculator className="h-5 w-5 text-primary" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="font-semibold text-foreground">Quick split total</div>
+                    <p className="text-sm text-muted-foreground">
+                      Best when you just know the total and want an answer fast.
+                    </p>
+                  </div>
+                  <div className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-primary">
+                    Set up quick split <ArrowRight className="h-4 w-4" />
+                  </div>
+                </button>
+
+                <div className="rounded-2xl border border-border bg-slate-50 p-5">
+                  <div className="mb-4 inline-flex rounded-xl bg-white p-2 shadow-sm">
+                    <PencilLine className="h-5 w-5 text-primary" />
+                  </div>
+                  <div className="space-y-3">
+                    <div>
+                      <div className="font-semibold text-foreground">Itemized bill</div>
+                      <p className="text-sm text-muted-foreground">
+                        Start with blank rows if you want fairness by item from the beginning.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="manual-title">Bill title</Label>
+                      <Input
+                        id="manual-title"
+                        value={manualTitle}
+                        onChange={(event) => setManualTitle(event.target.value)}
+                        placeholder="Manual Split"
+                      />
+                    </div>
+
+                    <Button type="button" className="w-full" onClick={startManualItemized}>
+                      Start itemized bill
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <DialogHeader>
+                <DialogTitle>Quick Split Total</DialogTitle>
+                <DialogDescription>
+                  This creates one shared line item now, and you can itemize it later if the group wants more detail.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-5">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="quick-title">Bill title</Label>
+                    <Input
+                      id="quick-title"
+                      value={quickTitle}
+                      onChange={(event) => setQuickTitle(event.target.value)}
+                      placeholder="Quick Split"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="quick-amount">Amount to split</Label>
+                    <Input
+                      id="quick-amount"
+                      inputMode="decimal"
+                      value={quickAmount}
+                      onChange={(event) => setQuickAmount(event.target.value)}
+                      placeholder="86.42"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      If this already includes tax and tip, leave the fields below blank.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="quick-tax">Tax</Label>
+                    <Input
+                      id="quick-tax"
+                      inputMode="decimal"
+                      value={quickTax}
+                      onChange={(event) => setQuickTax(event.target.value)}
+                      placeholder="0.00"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="quick-tip">Tip</Label>
+                    <Input
+                      id="quick-tip"
+                      inputMode="decimal"
+                      value={quickTip}
+                      onChange={(event) => setQuickTip(event.target.value)}
+                      placeholder="0.00"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="quick-discount">Discount</Label>
+                    <Input
+                      id="quick-discount"
+                      inputMode="decimal"
+                      value={quickDiscount}
+                      onChange={(event) => setQuickDiscount(event.target.value)}
+                      placeholder="0.00"
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="quick-split-mode">Split style</Label>
+                  <Select value={quickSplitMode} onValueChange={(value) => setQuickSplitMode(value as QuickSplitMode)}>
+                    <SelectTrigger id="quick-split-mode">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="even">
+                        <div className="flex items-center gap-2">
+                          <Percent className="h-4 w-4" />
+                          Split evenly
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="shares">
+                        <div className="flex items-center gap-2">
+                          <Scale className="h-4 w-4" />
+                          Weighted shares
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="exact">
+                        <div className="flex items-center gap-2">
+                          <DollarSign className="h-4 w-4" />
+                          Exact amounts
+                        </div>
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="text-sm font-semibold text-foreground">People</h3>
+                      <p className="text-xs text-muted-foreground">
+                        Add everyone involved in the split.
+                      </p>
+                    </div>
+                    <Button type="button" variant="outline" size="sm" onClick={addParticipant}>
+                      <Plus className="mr-1 h-4 w-4" />
+                      Add person
+                    </Button>
+                  </div>
+
+                  <div className="space-y-3">
+                    {participants.map((participant, index) => (
+                      <div key={participant.id} className="rounded-xl border border-border bg-slate-50 p-3">
+                        <div className="flex items-start gap-3">
+                          <div className="flex-1 space-y-2">
+                            <Label htmlFor={`participant-name-${participant.id}`}>Person {index + 1}</Label>
+                            <Input
+                              id={`participant-name-${participant.id}`}
+                              value={participant.name}
+                              onChange={(event) => updateParticipant(participant.id, "name", event.target.value)}
+                              placeholder={`Person ${index + 1}`}
+                            />
+                          </div>
+
+                          {participants.length > 2 && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="mt-6 shrink-0"
+                              onClick={() => removeParticipant(participant.id)}
+                              aria-label={`Remove person ${index + 1}`}
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          )}
+                        </div>
+
+                        {quickSplitMode === "shares" && (
+                          <div className="mt-3 space-y-2">
+                            <Label htmlFor={`participant-share-${participant.id}`}>Share weight</Label>
+                            <Input
+                              id={`participant-share-${participant.id}`}
+                              inputMode="decimal"
+                              value={participant.shares}
+                              onChange={(event) => updateParticipant(participant.id, "shares", event.target.value)}
+                              placeholder="1"
+                            />
+                          </div>
+                        )}
+
+                        {quickSplitMode === "exact" && (
+                          <div className="mt-3 space-y-2">
+                            <Label htmlFor={`participant-exact-${participant.id}`}>Exact amount</Label>
+                            <Input
+                              id={`participant-exact-${participant.id}`}
+                              inputMode="decimal"
+                              value={participant.exactAmount}
+                              onChange={(event) => updateParticipant(participant.id, "exactAmount", event.target.value)}
+                              placeholder="0.00"
+                            />
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {quickSplitError && (
+                  <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                    {quickSplitError}
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
+                  <Button type="button" variant="ghost" onClick={() => setManualMode("menu")}>
+                    Back
+                  </Button>
+                  <Button type="button" onClick={startQuickSplit} disabled={Boolean(quickSplitError)}>
+                    Create quick split
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+function StartOptionButton({
+  icon: Icon,
+  title,
+  description,
+  layout,
+}: {
+  icon: typeof Camera
+  title: string
+  description: string
+  layout: "sidebar" | "grid"
+}) {
+  const isSidebar = layout === "sidebar"
+
+  return (
+    <span
+      className={cn(
+        "block h-full rounded-2xl border border-border bg-slate-50 transition-colors hover:border-primary/50 hover:bg-primary/5",
+        isSidebar ? "p-4" : "p-5"
+      )}
+    >
+      <span
+        className={cn(
+          "inline-flex rounded-xl bg-white shadow-sm",
+          isSidebar ? "p-2.5" : "mb-3 p-2"
+        )}
+      >
+        <Icon className="h-5 w-5 text-primary" />
+      </span>
+
+      {isSidebar ? (
+        <span className="mt-3 flex items-start gap-3">
+          <span className="min-w-0 flex-1">
+            <span className="block font-semibold text-foreground">{title}</span>
+            <span className="mt-1 block text-sm leading-6 text-muted-foreground text-pretty">{description}</span>
+          </span>
+        </span>
+      ) : (
+        <>
+          <span className="block font-semibold text-foreground">{title}</span>
+          <span className="mt-1 block text-sm text-muted-foreground">{description}</span>
+        </>
+      )}
+    </span>
+  )
+}

--- a/components/BillStartOptions.tsx
+++ b/components/BillStartOptions.tsx
@@ -44,7 +44,9 @@ function createParticipantDraft(index: number): QuickSplitParticipantDraft {
 }
 
 function parseCurrencyValue(value: string) {
-  const trimmed = value.trim()
+  // Strip thousands separators so "1,200" parses as 1200 rather than parseFloat
+  // stopping at the comma and silently yielding 1.
+  const trimmed = value.trim().replace(/,/g, "")
   if (!trimmed) return 0
   const parsed = Number.parseFloat(trimmed)
   return Number.isFinite(parsed) ? parsed : NaN

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -1329,6 +1329,9 @@ function DesktopBillSplitter() {
 
       {/* --- Main Workspace --- */}
       <main id="main-content" className="pro-main">
+        {/* Single semantic page heading. Visually hidden so it doesn't disrupt
+            the spreadsheet UI, but gives crawlers a keyword-aligned H1. */}
+        <h1 className="sr-only">SplitSimple — split bills and group expenses by item, share, or exact amount</h1>
         {/* LEDGER VIEW */}
         {activeView === 'ledger' && (
           <div className="h-full w-full">

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -865,62 +865,65 @@ function DesktopBillSplitter() {
       return
     }
 
+    // Ignore spreadsheet hotkeys while focus is in other form controls like the bill title.
+    if (isInInput) {
+      return
+    }
+
     // Global shortcuts (only when not typing in other inputs)
-    if (!isInInput) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) {
-        e.preventDefault()
-        hotkeyActions.dispatchUndo()
-        hotkeyActions.toastUndo()
-        return
-      }
+    if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) {
+      e.preventDefault()
+      hotkeyActions.dispatchUndo()
+      hotkeyActions.toastUndo()
+      return
+    }
 
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'z') {
-        e.preventDefault()
-        hotkeyActions.dispatchRedo()
-        hotkeyActions.toastRedo()
-        return
-      }
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'z') {
+      e.preventDefault()
+      hotkeyActions.dispatchRedo()
+      hotkeyActions.toastRedo()
+      return
+    }
 
-      // Cmd+N: New bill
-      if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
-        e.preventDefault()
-        newBillSourceRef.current = "shortcut"
-        setIsNewBillDialogOpen(true)
-        return
-      }
+    // Cmd+N: New bill
+    if ((e.metaKey || e.ctrlKey) && e.key === 'n') {
+      e.preventDefault()
+      newBillSourceRef.current = "shortcut"
+      setIsNewBillDialogOpen(true)
+      return
+    }
 
-      // Cmd+Shift+N: Add new item
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'N') {
-        e.preventDefault()
-        hotkeyActions.addItem()
-        analytics.trackFeatureUsed("keyboard_shortcut_add_item")
-        return
-      }
+    // Cmd+Shift+N: Add new item
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'N') {
+      e.preventDefault()
+      hotkeyActions.addItem()
+      analytics.trackFeatureUsed("keyboard_shortcut_add_item")
+      return
+    }
 
-      // Cmd+Shift+P: Add person
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'P') {
-        e.preventDefault()
-        hotkeyActions.addPerson()
-        analytics.trackFeatureUsed("keyboard_shortcut_add_person")
-        return
-      }
+    // Cmd+Shift+P: Add person
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'P') {
+      e.preventDefault()
+      hotkeyActions.addPerson()
+      analytics.trackFeatureUsed("keyboard_shortcut_add_person")
+      return
+    }
 
-      // Cmd+Shift+C: Copy summary
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'C') {
-        e.preventDefault()
-        hotkeyActions.copyBreakdown()
-        analytics.trackFeatureUsed("keyboard_shortcut_copy")
-        return
-      }
+    // Cmd+Shift+C: Copy summary
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'C') {
+      e.preventDefault()
+      hotkeyActions.copyBreakdown()
+      analytics.trackFeatureUsed("keyboard_shortcut_copy")
+      return
+    }
 
-      // Cmd+S: Share
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 's') {
-        e.preventDefault()
-        const shareButton = document.querySelector('[data-share-trigger]') as HTMLButtonElement
-        if (shareButton) shareButton.click()
-        analytics.trackFeatureUsed("keyboard_shortcut_share")
-        return
-      }
+    // Cmd+S: Share
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 's') {
+      e.preventDefault()
+      const shareButton = document.querySelector('[data-share-trigger]') as HTMLButtonElement
+      if (shareButton) shareButton.click()
+      analytics.trackFeatureUsed("keyboard_shortcut_share")
+      return
     }
 
     // Grid navigation - Excel-like behavior
@@ -1054,11 +1057,11 @@ function DesktopBillSplitter() {
     previousItemsLengthRef.current = items.length
 
     if (activeView !== 'ledger') return
-    if (prevLen === 0 && items.length === 1) {
+    if (prevLen === 0 && items.length === 1 && !hasMeaningfulItems) {
       setSelectedCell({ row: 0, col: 'name' })
       setEditing(true)
     }
-  }, [activeView, items.length])
+  }, [activeView, hasMeaningfulItems, items.length])
 
   useEffect(() => {
     if (editing && editInputRef.current) {
@@ -1086,6 +1089,9 @@ function DesktopBillSplitter() {
                   onChange={(e) => {
                     dispatch({ type: 'SET_BILL_TITLE', payload: e.target.value })
                     analytics.trackTitleChanged(e.target.value)
+                  }}
+                  onKeyDown={(e) => {
+                    e.stopPropagation()
                   }}
                   style={{
                     width: `${Math.min(Math.max((title || '').length || 7, 7), 26)}ch`,

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -836,6 +836,14 @@ function DesktopBillSplitter() {
       }
     }
 
+    // A modal/dialog (Edit Member, New Bill, Share, Delete…) owns the keyboard while open.
+    // Its inputs live in a portal; when focus sits on the dialog container or a button
+    // inside it, isInInput is briefly false. Without this guard a printable key falls
+    // through to type-to-edit and silently edits the selected ledger cell behind the modal.
+    if (document.querySelector('[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]')) {
+      return
+    }
+
     // If currently editing a cell input, let typing happen but keep spreadsheet commits
     if (hotkeyState.editing && isInInput) {
       if (e.key === 'Enter') {

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -69,6 +69,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -2180,6 +2181,7 @@ function DesktopBillSplitter() {
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>Edit Member</DialogTitle>
+            <DialogDescription>Update this person's display name and color.</DialogDescription>
           </DialogHeader>
           {editingPerson && (
             <div className="space-y-5">

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -38,6 +38,7 @@ import { useIsMobile } from '@/hooks/use-mobile'
 import { MobileSpreadsheetView } from '@/components/MobileSpreadsheetView'
 import { AnimatedNumber } from '@/components/AnimatedNumber'
 import { SplitSimpleIcon } from '@/components/SplitSimpleIcon'
+import { BillStartOptions } from '@/components/BillStartOptions'
 import { ToastAction } from '@/components/ui/toast'
 import { getSplitMethodOption, splitMethodOptions } from '@/components/split-method-options'
 
@@ -1719,62 +1720,42 @@ function DesktopBillSplitter() {
                             <X size={16} />
                           </button>
                         </div>
-                        <div className="mt-4 space-y-2">
-                          {people.length === 0 ? (
-                            <button
-                              onClick={addPerson}
-                              className="w-full h-9 px-3 rounded-md bg-primary hover:bg-primary/90 text-xs font-bold text-white transition-transform active:scale-[0.97] flex items-center justify-between"
-                            >
-                              <span>Add first person</span>
-                              <span className="text-primary-foreground/70">{modKey}{shiftKey}P</span>
-                            </button>
-                          ) : (
-                            <button
-                              onClick={() => {
-                                if (items.length === 0) {
-                                  addItem()
-                                  return
-                                }
-                                setSelectedCell({ row: 0, col: 'name' })
-                                setEditing(true)
-                              }}
-                              className="w-full h-9 px-3 rounded-md bg-primary hover:bg-primary/90 text-xs font-bold text-white transition-transform active:scale-[0.97] flex items-center justify-between"
-                            >
-                              <span>Add items</span>
-                              <span className="text-primary-foreground/70">{modKey}{shiftKey}N</span>
-                            </button>
-                          )}
-                          {people.length === 0 ? (
-                            <button
-                              onClick={() => {
-                                addPerson()
-                                if (items.length === 0) {
-                                  addItem()
-                                }
-                              }}
-                              className="w-full h-9 px-3 rounded-md bg-muted hover:bg-muted-foreground/15 text-xs font-bold text-foreground transition-colors flex items-center justify-between"
-                              title="Adds a person first, then takes you to add items"
-                            >
-                              <span>Add items</span>
-                              <span className="text-muted-foreground">{modKey}{shiftKey}N</span>
-                            </button>
-                          ) : (
-                            <button
-                              onClick={addPerson}
-                              className="w-full h-9 px-3 rounded-md bg-muted hover:bg-muted-foreground/15 text-xs font-bold text-foreground transition-colors flex items-center justify-between"
-                            >
-                              <span>Add another person</span>
-                              <span className="text-muted-foreground">{modKey}{shiftKey}P</span>
-                            </button>
-                          )}
-                          <ReceiptScanner
-                            onImport={handleScanImport}
-                            trigger={(
-                              <button className="w-full h-9 px-3 rounded-md bg-muted hover:bg-muted-foreground/15 text-xs font-bold text-foreground transition-colors flex items-center gap-2">
-                                <Camera size={14} /> Scan receipt to import items
+                        <div className="mt-4 space-y-4">
+                          <BillStartOptions />
+
+                          <div className="space-y-2">
+                            {people.length === 0 ? (
+                              <button
+                                onClick={addPerson}
+                                className="w-full h-9 px-3 rounded-md bg-primary hover:bg-primary/90 text-xs font-bold text-white transition-transform active:scale-[0.97] flex items-center justify-between"
+                              >
+                                <span>Add first person</span>
+                                <span className="text-primary-foreground/70">{modKey}{shiftKey}P</span>
+                              </button>
+                            ) : (
+                              <button
+                                onClick={() => {
+                                  if (items.length === 0) {
+                                    addItem()
+                                    return
+                                  }
+                                  setSelectedCell({ row: 0, col: 'name' })
+                                  setEditing(true)
+                                }}
+                                className="w-full h-9 px-3 rounded-md bg-primary hover:bg-primary/90 text-xs font-bold text-white transition-transform active:scale-[0.97] flex items-center justify-between"
+                              >
+                                <span>Add items</span>
+                                <span className="text-primary-foreground/70">{modKey}{shiftKey}N</span>
                               </button>
                             )}
-                          />
+                            <button
+                              onClick={addPerson}
+                              className="w-full h-9 px-3 rounded-md bg-muted hover:bg-muted-foreground/15 text-xs font-bold text-foreground transition-colors flex items-center justify-between"
+                            >
+                              <span>{people.length === 0 ? "Add first person" : "Add another person"}</span>
+                              <span className="text-muted-foreground">{modKey}{shiftKey}P</span>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     )}

--- a/components/ReceiptScanner.tsx
+++ b/components/ReceiptScanner.tsx
@@ -36,9 +36,10 @@ interface ScanError {
 interface ReceiptScannerProps {
   onImport: (items: ReceiptLineItem[]) => void
   trigger?: React.ReactNode
+  initialTab?: "image" | "text"
 }
 
-export function ReceiptScanner({ onImport, trigger }: ReceiptScannerProps) {
+export function ReceiptScanner({ onImport, trigger, initialTab = "image" }: ReceiptScannerProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [state, setState] = useState<ScannerState>('idle')
   const [receiptImage, setReceiptImage] = useState<string | null>(null)
@@ -46,6 +47,7 @@ export function ReceiptScanner({ onImport, trigger }: ReceiptScannerProps) {
   const [zoom, setZoom] = useState(1)
   const [rotation, setRotate] = useState(0)
   const [error, setError] = useState<ScanError | null>(null)
+  const [activeTab, setActiveTab] = useState<"image" | "text">(initialTab)
   const { toast } = useToast()
 
   const handleReset = useCallback(() => {
@@ -55,10 +57,14 @@ export function ReceiptScanner({ onImport, trigger }: ReceiptScannerProps) {
     setZoom(1)
     setRotate(0)
     setError(null)
-  }, [])
+    setActiveTab(initialTab)
+  }, [initialTab])
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open)
+    if (open) {
+      setActiveTab(initialTab)
+    }
     if (!open) {
       setTimeout(handleReset, 300) // Reset after animation
     }
@@ -195,10 +201,12 @@ export function ReceiptScanner({ onImport, trigger }: ReceiptScannerProps) {
       )}>
         {state === 'idle' && (
           <UploadView
+            activeTab={activeTab}
             onUpload={processImage}
             onPaste={handlePasteText}
             error={error}
             onDismissError={() => setError(null)}
+            onTabChange={setActiveTab}
           />
         )}
 
@@ -227,15 +235,19 @@ export function ReceiptScanner({ onImport, trigger }: ReceiptScannerProps) {
 // --- Sub-Components ---
 
 function UploadView({
+  activeTab,
   onUpload,
   onPaste,
   error,
-  onDismissError
+  onDismissError,
+  onTabChange,
 }: {
+  activeTab: "image" | "text"
   onUpload: (file: File) => void
   onPaste: (text: string) => void
   error: ScanError | null
   onDismissError: () => void
+  onTabChange: (value: "image" | "text") => void
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [dragActive, setDragActive] = useState(false)
@@ -262,11 +274,11 @@ function UploadView({
 
   return (
     <div className="flex flex-col h-full">
-      <DialogHeader className="p-6 pb-2 border-b border-slate-100">
-        <DialogTitle>Add Receipt</DialogTitle>
-      </DialogHeader>
+        <DialogHeader className="p-6 pb-2 border-b border-slate-100">
+          <DialogTitle>Add Items</DialogTitle>
+        </DialogHeader>
       
-      <Tabs defaultValue="image" className="flex-1 flex flex-col">
+      <Tabs value={activeTab} onValueChange={(value) => onTabChange(value as "image" | "text")} className="flex-1 flex flex-col">
         <div className="px-6 pt-4">
           <TabsList className="w-full grid grid-cols-2">
             <TabsTrigger value="image"><ImageIcon className="w-4 h-4 mr-2" /> Upload Image</TabsTrigger>

--- a/components/ShareBill.tsx
+++ b/components/ShareBill.tsx
@@ -30,6 +30,8 @@ export function ShareBill({ variant = "outline", size = "sm", showText = true, i
   const [isStoring, setIsStoring] = useState(false)
   const [shareUrl, setShareUrl] = useState("")
   const [storeError, setStoreError] = useState<string | null>(null)
+  const isSharedCopy = state.billSource === "shared_copy"
+  const shareTriggerLabel = isSharedCopy ? "Share updated copy" : "Share"
 
   // Generate share URL when dialog opens
   const handleOpenDialog = async (open: boolean) => {
@@ -158,20 +160,23 @@ export function ShareBill({ variant = "outline", size = "sm", showText = true, i
           id={id ?? "share-bill-trigger"}  // Allow external triggering via document.getElementById()
           variant={variant}
           size={size}
+          aria-label={shareTriggerLabel}
           className={showText ? "flex items-center gap-1.5 btn-smooth" : "dock-item p-0 h-auto bg-transparent border-0 hover:bg-primary/10"}
         >
           <Share2 className={showText ? "h-4 w-4 transition-transform duration-200 group-hover:scale-110" : "h-5 w-5 text-foreground"} />
-          {showText && <span>Share</span>}
+          {showText && <span>{shareTriggerLabel}</span>}
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-[95vw] sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Share2 className="h-5 w-5" />
-            Share & Export "{state.currentBill.title}"
+            {isSharedCopy ? `Share updated copy "${state.currentBill.title}"` : `Share & Export "${state.currentBill.title}"`}
           </DialogTitle>
           <DialogDescription>
-            Share a link with anyone or export your bill data. Bills are stored securely and expire after 6 months.
+            {isSharedCopy
+              ? "This creates a new link for your edited copy. The original shared bill stays unchanged."
+              : "Share a link with anyone or export your bill data. Bills are stored securely and expire after 1 year."}
           </DialogDescription>
         </DialogHeader>
         
@@ -245,7 +250,7 @@ export function ShareBill({ variant = "outline", size = "sm", showText = true, i
 
           <Alert>
             <AlertDescription className="text-sm">
-              <strong>✅ Universal sharing:</strong> This link works for anyone and auto-deletes after 6 months. 
+              <strong>✅ Universal sharing:</strong> This link works for anyone and auto-deletes after 1 year. 
               Bills are stored securely in the cloud.
             </AlertDescription>
           </Alert>

--- a/components/__tests__/ProBillSplitterTitleInput.test.tsx
+++ b/components/__tests__/ProBillSplitterTitleInput.test.tsx
@@ -1,0 +1,64 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@/tests/utils/test-utils'
+import { ProBillSplitter } from '@/components/ProBillSplitter'
+import { createMockBill, createMockItem } from '@/tests/utils/test-utils'
+import { useBill } from '@/contexts/BillContext'
+
+function BillStateProbe() {
+  const { state } = useBill()
+
+  return (
+    <div>
+      <output data-testid="probe-title">{state.currentBill.title}</output>
+      <output data-testid="probe-first-item-name">{state.currentBill.items[0]?.name ?? ''}</output>
+    </div>
+  )
+}
+
+describe('ProBillSplitter bill title input', () => {
+  it('does not start editing the selected ledger cell while typing in the bill title', async () => {
+    const user = userEvent.setup()
+
+    const bill = createMockBill({
+      id: 'bill-title-bug',
+      title: 'Dinner',
+      items: [
+        createMockItem({
+          id: 'item-1',
+          name: 'Pad Thai',
+        }),
+      ],
+    })
+
+    window.localStorage.getItem = jest.fn((key: string) => {
+      if (key === 'splitSimple_currentBill') {
+        return JSON.stringify(bill)
+      }
+
+      return null
+    })
+
+    render(
+      <>
+        <ProBillSplitter />
+        <BillStateProbe />
+      </>
+    )
+
+    const titleInput = await screen.findByRole('textbox', { name: /bill title/i })
+
+    await waitFor(() => {
+      expect(titleInput).toHaveValue('Dinner')
+      expect(screen.getByTestId('probe-title')).toHaveTextContent('Dinner')
+      expect(screen.getByTestId('probe-first-item-name')).toHaveTextContent('Pad Thai')
+    })
+
+    await user.click(titleInput)
+    await user.type(titleInput, 'X')
+
+    expect(titleInput).toHaveValue('DinnerX')
+    expect(screen.getByTestId('probe-title')).toHaveTextContent('DinnerX')
+    expect(screen.getByTestId('probe-first-item-name')).toHaveTextContent('Pad Thai')
+    expect(screen.queryByLabelText(/edit name/i)).not.toBeInTheDocument()
+  })
+})

--- a/components/__tests__/SharedBillUi.test.tsx
+++ b/components/__tests__/SharedBillUi.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BillSourceIndicator } from '@/components/BillSourceIndicator'
+import { ShareBill } from '@/components/ShareBill'
+import { createMockBill } from '@/tests/utils/test-utils'
+import { useBill } from '@/contexts/BillContext'
+import { useRouter } from 'next/navigation'
+import { storeBillInCloud, generateCloudShareUrl } from '@/lib/sharing'
+
+jest.mock('@/contexts/BillContext', () => ({
+  useBill: jest.fn(),
+}))
+
+const mockPush = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}))
+
+jest.mock('@/hooks/use-analytics', () => ({
+  useBillAnalytics: () => ({
+    trackShareBillClicked: jest.fn(),
+    trackFeatureUsed: jest.fn(),
+    trackError: jest.fn(),
+  }),
+}))
+
+jest.mock('@/lib/sharing', () => {
+  const actual = jest.requireActual('@/lib/sharing')
+
+  return {
+    ...actual,
+    storeBillInCloud: jest.fn(),
+    generateCloudShareUrl: jest.fn(),
+  }
+})
+
+const mockedUseBill = jest.mocked(useBill)
+const mockedUseRouter = jest.mocked(useRouter)
+const mockedStoreBillInCloud = jest.mocked(storeBillInCloud)
+const mockedGenerateCloudShareUrl = jest.mocked(generateCloudShareUrl)
+
+function createMockRouter() {
+  return {
+    push: mockPush,
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  }
+}
+
+function mockBillState(overrides: Partial<ReturnType<typeof createMockBill>> = {}, billSource: 'draft' | 'shared' | 'shared_copy' = 'draft', sharedOriginBillId: string | null = null) {
+  mockedUseBill.mockReturnValue({
+    state: {
+      currentBill: createMockBill(overrides),
+      billSource,
+      sharedOriginBillId,
+      syncStatus: 'never_synced',
+      lastSyncTime: null,
+      history: [],
+      historyIndex: -1,
+      maxHistorySize: 50,
+    },
+    dispatch: jest.fn(),
+    canUndo: false,
+    canRedo: false,
+    syncToCloud: jest.fn(),
+  })
+}
+
+describe('BillSourceIndicator', () => {
+  beforeEach(() => {
+    mockPush.mockReset()
+    mockedUseRouter.mockReturnValue(createMockRouter() as unknown as ReturnType<typeof useRouter>)
+  })
+
+  it('shows a forked shared-bill label and reload action for local copies', () => {
+    mockBillState({ id: 'forked-bill-id' }, 'shared_copy', 'shared-bill-id')
+
+    render(<BillSourceIndicator />)
+
+    expect(screen.getByText('Forked from shared bill')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reload original/i })).toBeInTheDocument()
+  })
+
+  it('reopens the original shared bill from a forked copy', async () => {
+    const user = userEvent.setup()
+    mockBillState({ id: 'forked-bill-id' }, 'shared_copy', 'shared-bill-id')
+
+    render(<BillSourceIndicator />)
+
+    await user.click(screen.getByRole('button', { name: /reload original/i }))
+
+    expect(mockPush).toHaveBeenCalledWith('/b/shared-bill-id', { scroll: false })
+  })
+
+  it('keeps the shared bill indicator simple when viewing the original', () => {
+    mockBillState({ id: 'shared-bill-id' }, 'shared', 'shared-bill-id')
+
+    render(<BillSourceIndicator />)
+
+    expect(screen.getByText('Viewing shared bill')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /reload original/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('ShareBill', () => {
+  beforeEach(() => {
+    mockedUseRouter.mockReturnValue(createMockRouter() as unknown as ReturnType<typeof useRouter>)
+    mockedStoreBillInCloud.mockResolvedValue({ success: true })
+    mockedGenerateCloudShareUrl.mockImplementation((billId: string) => `https://splitsimple.app/b/${billId}`)
+  })
+
+  it('updates the trigger label for shared copies', () => {
+    mockBillState({ id: 'forked-bill-id', title: 'Edited Bill' }, 'shared_copy', 'shared-bill-id')
+
+    render(<ShareBill />)
+
+    expect(screen.getByRole('button', { name: /share updated copy/i })).toBeInTheDocument()
+  })
+
+  it('explains that sharing a fork keeps the original untouched', async () => {
+    const user = userEvent.setup()
+    mockBillState({ id: 'forked-bill-id', title: 'Edited Bill' }, 'shared_copy', 'shared-bill-id')
+
+    render(<ShareBill />)
+
+    await user.click(screen.getByRole('button', { name: /share updated copy/i }))
+
+    expect(await screen.findByText(/original shared bill stays unchanged/i)).toBeInTheDocument()
+  })
+})

--- a/components/mobile/MobileCardView.tsx
+++ b/components/mobile/MobileCardView.tsx
@@ -27,7 +27,7 @@ import {
   Edit2
 } from "lucide-react"
 import { useBill } from "@/contexts/BillContext"
-import type { Item, Person, ReceiptLineItem } from "@/lib/bill-types"
+import type { Item, Person } from "@/lib/bill-types"
 import { calculateItemSplits, getBillSummary } from "@/lib/calculations"
 import { PersonSelector } from "@/components/PersonSelector"
 import { SplitMethodSelector } from "@/components/SplitMethodSelector"
@@ -40,7 +40,7 @@ import { useBillAnalytics } from "@/hooks/use-analytics"
 import { SplitSimpleIcon } from "@/components/SplitSimpleIcon"
 import { BillLookup } from "@/components/BillLookup"
 import { ShareBill } from "@/components/ShareBill"
-import { ReceiptScanner } from "@/components/ReceiptScanner"
+import { BillStartOptions } from "@/components/BillStartOptions"
 import { cn } from "@/lib/utils"
 
 // Color palette for people
@@ -112,19 +112,6 @@ export function MobileCardView() {
     } else {
       toast({ title: "Copy failed", description: "Please try again", variant: "destructive" })
     }
-  }
-
-  const handleScanImport = (scannedItems: ReceiptLineItem[]) => {
-    scannedItems.forEach((item) => {
-      const newItem: Omit<Item, "id"> = {
-        ...item,
-        splitWith: people.map((p) => p.id),
-        method: "even",
-      }
-      dispatch({ type: "ADD_ITEM", payload: newItem })
-    })
-    analytics.trackFeatureUsed("scan_receipt_import", { count: scannedItems.length })
-    toast({ title: "Items added from scan" })
   }
 
   const handleNewBill = () => {
@@ -279,16 +266,13 @@ export function MobileCardView() {
 
             {items.length === 0 ? (
               <Card>
-                <CardContent className="p-8 text-center space-y-4">
+                <CardContent className="p-6 text-center space-y-4">
                   <div className="text-4xl">📝</div>
                   <div>
                     <p className="font-semibold mb-1">No items yet</p>
-                    <p className="text-sm text-muted-foreground">Add your first item to start splitting</p>
+                    <p className="text-sm text-muted-foreground">Start with a receipt, pasted text, or a manual split.</p>
                   </div>
-                  <Button onClick={handleAddItem} className="w-full">
-                    <Plus className="h-4 w-4 mr-2" />
-                    Add Item
-                  </Button>
+                  <BillStartOptions compact />
                 </CardContent>
               </Card>
             ) : (

--- a/lib/__tests__/bill-start.test.ts
+++ b/lib/__tests__/bill-start.test.ts
@@ -1,0 +1,57 @@
+import { getBillSummary } from "@/lib/calculations"
+import { buildManualItemizedBill, buildQuickSplitBill } from "@/lib/bill-start"
+
+describe("bill-start helpers", () => {
+  it("builds an even quick split bill that reconciles", () => {
+    const bill = buildQuickSplitBill({
+      title: "Bar tab",
+      amount: 80,
+      tax: 6.4,
+      tip: 13.6,
+      participants: [
+        { name: "Anurag" },
+        { name: "Sunil" },
+        { name: "Praks" },
+        { name: "Shambhavi" },
+      ],
+    })
+
+    const summary = getBillSummary(bill)
+
+    expect(bill.items).toHaveLength(1)
+    expect(summary.subtotal).toBe(80)
+    expect(summary.tax).toBe(6.4)
+    expect(summary.tip).toBe(13.6)
+    expect(summary.total).toBe(100)
+    expect(summary.personTotals).toHaveLength(4)
+    expect(summary.personTotals.every((person) => person.total === 25)).toBe(true)
+  })
+
+  it("builds an exact quick split bill with person amounts", () => {
+    const bill = buildQuickSplitBill({
+      title: "Taxi",
+      amount: 42,
+      splitMode: "exact",
+      participants: [
+        { name: "Anurag", exactAmount: 12 },
+        { name: "Sunil", exactAmount: 10 },
+        { name: "Praks", exactAmount: 20 },
+      ],
+    })
+
+    const summary = getBillSummary(bill)
+
+    expect(summary.total).toBe(42)
+    expect(summary.personTotals.map((person) => person.total)).toEqual([12, 10, 20])
+  })
+
+  it("builds a manual itemized draft with starter rows", () => {
+    const bill = buildManualItemizedBill("Groceries")
+
+    expect(bill.title).toBe("Groceries")
+    expect(bill.people).toHaveLength(1)
+    expect(bill.items).toHaveLength(3)
+    expect(bill.items.every((item) => item.quantity === 1 && item.method === "even")).toBe(true)
+    expect(bill.items.every((item) => item.splitWith.length === 1)).toBe(true)
+  })
+})

--- a/lib/__tests__/constants.test.ts
+++ b/lib/__tests__/constants.test.ts
@@ -1,0 +1,7 @@
+import { STORAGE } from '@/lib/constants'
+
+describe('shared bill storage constants', () => {
+  it('keeps shared bills available for one year by default', () => {
+    expect(STORAGE.BILL_TTL_SECONDS).toBe(365 * 24 * 60 * 60)
+  })
+})

--- a/lib/__tests__/shared-bill-og.test.ts
+++ b/lib/__tests__/shared-bill-og.test.ts
@@ -1,0 +1,67 @@
+import { buildQuickSplitBill } from "@/lib/bill-start"
+import { buildSharedBillOgModel } from "@/lib/shared-bill-og"
+import type { Bill } from "@/lib/bill-types"
+
+const baseBill: Bill = {
+  id: "bill-1",
+  title: "Dinner at Nopa",
+  status: "active",
+  tax: "",
+  tip: "",
+  discount: "",
+  taxTipAllocation: "proportional",
+  notes: "",
+  people: [
+    { id: "p1", name: "Anurag", color: "#000", colorIdx: 0 },
+    { id: "p2", name: "Sunil", color: "#111", colorIdx: 1 },
+  ],
+  items: [],
+}
+
+describe("buildSharedBillOgModel", () => {
+  it("derives title, plural people label, and currency total", () => {
+    const bill = buildQuickSplitBill({
+      title: "Dinner at Nopa",
+      amount: 180,
+      tax: 6.4,
+      participants: [{ name: "Anurag" }, { name: "Sunil" }, { name: "Praks" }, { name: "Shambhavi" }],
+    })
+
+    const model = buildSharedBillOgModel(bill)
+
+    expect(model.title).toBe("Dinner at Nopa")
+    expect(model.peopleLabel).toBe("4 people")
+    expect(model.totalLabel).toBe("$186.40")
+  })
+
+  it("uses the singular form for a single participant", () => {
+    const model = buildSharedBillOgModel({ ...baseBill, people: [baseBill.people[0]] })
+    expect(model.peopleLabel).toBe("1 person")
+  })
+
+  it("formats large totals with thousands separators", () => {
+    const bill = buildQuickSplitBill({
+      title: "Group trip",
+      amount: 1234.5,
+      participants: [{ name: "A" }, { name: "B" }],
+    })
+    expect(buildSharedBillOgModel(bill).totalLabel).toBe("$1,234.50")
+  })
+
+  it("truncates overly long titles with an ellipsis", () => {
+    const longTitle = "A really long dinner title that will not fit on the card at all"
+    const model = buildSharedBillOgModel({ ...baseBill, title: longTitle })
+    expect(model.title.endsWith("…")).toBe(true)
+    expect(model.title.length).toBeLessThanOrEqual(40)
+  })
+
+  it("falls back to a generic title when the bill title is blank", () => {
+    const model = buildSharedBillOgModel({ ...baseBill, title: "   " })
+    expect(model.title).toBe("Shared bill")
+  })
+
+  it("reports a zero total for an empty bill", () => {
+    const model = buildSharedBillOgModel({ ...baseBill, items: [] })
+    expect(model.totalLabel).toBe("$0.00")
+  })
+})

--- a/lib/bill-start.ts
+++ b/lib/bill-start.ts
@@ -1,16 +1,15 @@
 import type { Bill, Item, Person } from "@/lib/bill-types"
 
+// Mirrors the canonical `COLORS` palette in ProBillSplitter (hex values, same order).
+// `color` and `colorIdx` are both derived from this single source so the stored hex
+// always matches the swatch the Pro view renders via COLORS[colorIdx].
 const PERSON_COLORS = [
-  "#6366f1",
-  "#d97706",
-  "#dc2626",
-  "#22c55e",
-  "#f59e0b",
-  "#8b5cf6",
-  "#06b6d4",
-  "#ef4444",
-  "#10b981",
-  "#f97316",
+  "#4F46E5", // indigo
+  "#F97316", // orange
+  "#F43F5E", // rose
+  "#10B981", // emerald
+  "#3B82F6", // blue
+  "#F59E0B", // amber
 ]
 
 function createId() {
@@ -51,12 +50,15 @@ export function buildQuickSplitBill(input: QuickSplitDraftInput): Bill {
   const tip = sanitizeAmount(input.tip ?? 0)
   const discount = sanitizeAmount(input.discount ?? 0)
 
-  const people: Person[] = input.participants.map((participant, index) => ({
-    id: createId(),
-    name: participant.name.trim(),
-    color: PERSON_COLORS[index % PERSON_COLORS.length],
-    colorIdx: index % 6,
-  }))
+  const people: Person[] = input.participants.map((participant, index) => {
+    const colorIdx = index % PERSON_COLORS.length
+    return {
+      id: createId(),
+      name: participant.name.trim(),
+      color: PERSON_COLORS[colorIdx],
+      colorIdx,
+    }
+  })
 
   const item: Item = {
     id: createId(),

--- a/lib/bill-start.ts
+++ b/lib/bill-start.ts
@@ -1,0 +1,125 @@
+import type { Bill, Item, Person } from "@/lib/bill-types"
+
+const PERSON_COLORS = [
+  "#6366f1",
+  "#d97706",
+  "#dc2626",
+  "#22c55e",
+  "#f59e0b",
+  "#8b5cf6",
+  "#06b6d4",
+  "#ef4444",
+  "#10b981",
+  "#f97316",
+]
+
+function createId() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+function sanitizeAmount(value: number) {
+  return Math.max(0, Math.round(value * 100) / 100)
+}
+
+function formatAmount(value: number) {
+  return sanitizeAmount(value).toFixed(2)
+}
+
+export type QuickSplitMode = "even" | "shares" | "exact"
+
+export interface QuickSplitParticipantInput {
+  name: string
+  shares?: number
+  exactAmount?: number
+}
+
+export interface QuickSplitDraftInput {
+  title: string
+  amount: number
+  tax?: number
+  tip?: number
+  discount?: number
+  allocation?: "proportional" | "even"
+  splitMode?: QuickSplitMode
+  participants: QuickSplitParticipantInput[]
+}
+
+export function buildQuickSplitBill(input: QuickSplitDraftInput): Bill {
+  const splitMode = input.splitMode ?? "even"
+  const amount = sanitizeAmount(input.amount)
+  const tax = sanitizeAmount(input.tax ?? 0)
+  const tip = sanitizeAmount(input.tip ?? 0)
+  const discount = sanitizeAmount(input.discount ?? 0)
+
+  const people: Person[] = input.participants.map((participant, index) => ({
+    id: createId(),
+    name: participant.name.trim(),
+    color: PERSON_COLORS[index % PERSON_COLORS.length],
+    colorIdx: index % 6,
+  }))
+
+  const item: Item = {
+    id: createId(),
+    name: "Shared total",
+    price: formatAmount(amount),
+    quantity: 1,
+    splitWith: people.map((person) => person.id),
+    method: splitMode,
+  }
+
+  if (splitMode === "shares") {
+    item.customSplits = Object.fromEntries(
+      people.map((person, index) => [person.id, input.participants[index]?.shares ?? 1])
+    )
+  }
+
+  if (splitMode === "exact") {
+    item.customSplits = Object.fromEntries(
+      people.map((person, index) => [person.id, sanitizeAmount(input.participants[index]?.exactAmount ?? 0)])
+    )
+  }
+
+  return {
+    id: createId(),
+    title: input.title.trim() || "Quick Split",
+    status: "active",
+    tax: tax > 0 ? formatAmount(tax) : "",
+    tip: tip > 0 ? formatAmount(tip) : "",
+    discount: discount > 0 ? formatAmount(discount) : "",
+    taxTipAllocation: input.allocation ?? "proportional",
+    notes: "",
+    people,
+    items: [item],
+  }
+}
+
+export function buildManualItemizedBill(title = "Manual Split"): Bill {
+  const firstPerson: Person = {
+    id: createId(),
+    name: "Person 1",
+    color: PERSON_COLORS[0],
+    colorIdx: 0,
+  }
+
+  const starterItems: Item[] = Array.from({ length: 3 }, () => ({
+    id: createId(),
+    name: "",
+    price: "",
+    quantity: 1,
+    splitWith: [firstPerson.id],
+    method: "even" as const,
+  }))
+
+  return {
+    id: createId(),
+    title: title.trim() || "Manual Split",
+    status: "active",
+    tax: "",
+    tip: "",
+    discount: "",
+    taxTipAllocation: "proportional",
+    notes: "",
+    people: [firstPerson],
+    items: starterItems,
+  }
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -23,5 +23,5 @@ export const TIMING = {
 
 // Shared bill storage constants
 export const STORAGE = {
-  BILL_TTL_SECONDS: 15552000, // ~6 months (6 * 30 days)
+  BILL_TTL_SECONDS: 31536000, // 1 year (365 days)
 } as const

--- a/lib/load-shared-bill.ts
+++ b/lib/load-shared-bill.ts
@@ -1,0 +1,35 @@
+// Importing next/headers makes this module server-only: it throws if pulled
+// into a Client Component, so a separate "server-only" guard is unnecessary.
+import { headers } from "next/headers"
+import type { Bill } from "@/lib/bill-types"
+import { isMigratableBill, isRecord, migrateBillSchema } from "@/lib/validation"
+
+const SHARED_BILL_REVALIDATE_SECONDS = 300
+
+// Server-side load of a shared bill for metadata and OG-image rendering.
+// Reuses the existing /api/bills proxy (backend URL + shared secret handled
+// there) via the request's own origin, so no backend wiring is duplicated.
+// Returns null on any failure so callers can fall back to generic, data-free
+// output rather than crashing the page or image render.
+export async function loadSharedBill(billId: string): Promise<Bill | null> {
+  try {
+    const headerList = await headers()
+    const host = headerList.get("host")
+    if (!host) return null
+
+    const protocol = headerList.get("x-forwarded-proto") ?? "https"
+    const response = await fetch(`${protocol}://${host}/api/bills/${encodeURIComponent(billId)}`, {
+      headers: { accept: "application/json" },
+      next: { revalidate: SHARED_BILL_REVALIDATE_SECONDS },
+    })
+    if (!response.ok) return null
+
+    const data: unknown = await response.json()
+    const bill = isRecord(data) ? data.bill : undefined
+    return isMigratableBill(bill) ? migrateBillSchema(bill) : null
+  } catch {
+    return null
+  }
+}
+
+export { SHARED_BILL_REVALIDATE_SECONDS }

--- a/lib/shared-bill-og.ts
+++ b/lib/shared-bill-og.ts
@@ -1,0 +1,43 @@
+import type { Bill } from "@/lib/bill-types"
+import { getBillSummary } from "@/lib/calculations"
+
+const MAX_TITLE_LENGTH = 40
+
+export interface SharedBillOgModel {
+  /** Bill title, trimmed and truncated for the card headline. */
+  title: string
+  /** Pluralized participant count, e.g. "1 person" / "4 people". */
+  peopleLabel: string
+  /** Currency-formatted grand total, e.g. "$186.40". */
+  totalLabel: string
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value
+  // Trim trailing whitespace left behind by the cut so the ellipsis reads cleanly.
+  return `${value.slice(0, max - 1).trimEnd()}…`
+}
+
+function formatCurrency(amount: number): string {
+  const safeAmount = Number.isFinite(amount) ? amount : 0
+  return `$${safeAmount.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+/**
+ * Derives the privacy-conscious fields shown on a shared bill's social card.
+ * Intentionally exposes only the title, participant count, and grand total —
+ * never individual names or per-person amounts.
+ */
+export function buildSharedBillOgModel(bill: Bill): SharedBillOgModel {
+  const peopleCount = bill.people.length
+  const trimmedTitle = bill.title.trim()
+
+  return {
+    title: trimmedTitle ? truncate(trimmedTitle, MAX_TITLE_LENGTH) : "Shared bill",
+    peopleLabel: `${peopleCount} ${peopleCount === 1 ? "person" : "people"}`,
+    totalLabel: formatCurrency(getBillSummary(bill).total),
+  }
+}

--- a/lib/sharing.ts
+++ b/lib/sharing.ts
@@ -147,7 +147,7 @@ export async function getBillFromCloud(billId: string): Promise<CloudBillResult>
 
     if (!response.ok) {
       if (response.status === 404) {
-        return { error: "We couldn't find that bill. Bills expire after 6 months — ask the owner for a fresh link, or double-check the ID." }
+        return { error: "We couldn't find that bill. Bills expire after 1 year — ask the owner for a fresh link, or double-check the ID." }
       }
 
       let errorMessage = 'Something went wrong loading this bill. Please try again.'

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  allowedDevOrigins: ["127.0.0.1"],
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary
- Make shared-bill editing, syncing, and one-year sharing behavior explicit and safe
- Add first-class non-scan entry paths: scan, paste text, and manual quick-split / itemized starts
- Harden the admin dashboard around auth, pagination, fetch races, and backend errors
- Add per-bill social previews and baseline SEO (crawl rules, sitemap, structured data, on-page)

## What changed

### Shared bill flows
- Shared bills fork to an explicit copy on edit, with clearer source indicators and updated sharing copy
- Editing a bill title no longer triggers accidental ledger-name editing
- Shared-bill expiry extended from six months to one year
- Dedicated `/b/[billId]` routes (legacy `/?bill=` / `/?share=` links redirect in)

### Non-scan entry paths
- Starter flow exposes three entry points: **Scan receipt**, **Paste order text**, **Enter manually**
- **Enter manually** opens either a quick total-split flow or a starter itemized bill
- Quick split supports even / weighted-shares / exact-amount modes with live validation
- Receipt import can open directly into the text-paste path

### Admin dashboard hardening
- Handles expired sessions, empty states, clamped pagination, and backend error messages
- Guards the bills fetch against aborted-request races (controller identity check)
- Resets the loading flag correctly on unauthorized teardown

### Per-bill social previews (Open Graph)
- Colocated `next/og` `opengraph-image` route renders each shared link with its own **title, people count, and total** on a dark, feed-optimized card
- `generateMetadata` keeps the link's title/description and `summary_large_image` Twitter card in sync
- Branded, data-free fallback card for missing/expired bills
- Privacy-conscious by design: exposes only title / count / total — never names or per-person amounts

### SEO
- `noindex, nofollow` on shared bills (random-ID pages with user financial data should never be indexed; social scrapers still get the OG preview)
- New `app/robots.ts` (disallow `/admin`, `/b/`, `/api/`, `/og-image`; sitemap + host) and `app/sitemap.ts`
- Single semantic `<h1>` on the homepage (previously none)
- `WebApplication` / `FinanceApplication` JSON-LD on the homepage for rich results and AI answer engines
- Expanded the thin (~55 char) meta description to a keyword-aligned ~150 chars

### Smaller fixes
- Quick-split currency parsing strips thousands separators (`"1,200"` was parsing as `1`)
- `DialogDescription` added to the Edit Member dialog (a11y)
- Quick-split palette aligned with the canonical Pro colors; blocked a grid hotkey leak under modals
- Readable backend-proxy failures; `127.0.0.1` allowed as a dev origin for hot reload

## Verification
- `npm run typecheck` — clean
- `npm run build` — succeeds (`/robots.txt`, `/sitemap.xml`, and the OG route generate)
- `npm test` — **181 passed** (20 suites + new `shared-bill-og` suite)
- Live dev-server checks: OG cards render (real bill + fallback), shared-bill `noindex`, `robots.txt` / `sitemap.xml` output, homepage single `<h1>` + JSON-LD + expanded description, admin `noindex` unchanged

## Notes
- Left `images.unoptimized` as-is: the only `next/image` (receipt preview) already opts out per-element and the indexable homepage has no content images, so changing it offers no SEO benefit
- Generated local files (`next-env.d.ts`, `.playwright-cli/`) intentionally excluded
- **Follow-up (manual):** submit `https://splitsimple.anuragd.me/sitemap.xml` in Google Search Console to activate the sitemap
