### PR TITLE
Fix dead micro-interactions and polish animation craft

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -528,7 +528,7 @@
 
   .clickable-badge:hover {
     transform: scale(1.05);
-    box-shadow: 0 0 0 3px rgba(var(--primary), 0.1);
+    box-shadow: 0 0 0 3px oklch(from var(--primary) l c h / 0.1);
   }
 
   .clickable-badge:active {
@@ -540,7 +540,7 @@
   textarea:focus,
   select:focus {
     @apply outline-none ring-2 ring-primary ring-offset-2;
-    background-color: rgba(var(--primary), 0.02);
+    background-color: oklch(from var(--primary) l c h / 0.02);
     transition:
       box-shadow 0.2s var(--ease-out-cubic),
       border-color 0.2s var(--ease-out-cubic),
@@ -584,10 +584,10 @@
   /* Success ripple effect */
   @keyframes success-ripple {
     0% {
-      box-shadow: 0 0 0 0 rgba(var(--success), 0.4);
+      box-shadow: 0 0 0 0 oklch(from var(--success) l c h / 0.4);
     }
     100% {
-      box-shadow: 0 0 0 10px rgba(var(--success), 0);
+      box-shadow: 0 0 0 10px oklch(from var(--success) l c h / 0);
     }
   }
 
@@ -630,15 +630,15 @@
   /* Pulse animation for new inputs */
   @keyframes pulse-border {
     0%, 100% {
-      box-shadow: 0 0 0 0 rgba(var(--primary), 0.4);
+      box-shadow: 0 0 0 0 oklch(from var(--primary) l c h / 0.4);
     }
     50% {
-      box-shadow: 0 0 0 4px rgba(var(--primary), 0.1);
+      box-shadow: 0 0 0 4px oklch(from var(--primary) l c h / 0.1);
     }
   }
 
   .input-focus-hint {
-    animation: pulse-border 0.3s ease-in-out 3;
+    animation: pulse-border 0.3s ease-out 2;
   }
 
   /* Stagger slide-in animations */
@@ -738,17 +738,15 @@
   }
 
   .ledger-row {
-    @apply border-b border-border transition-[transform,box-shadow,background-color,border-color] duration-200;
+    @apply border-b border-border transition-[box-shadow,background-color,border-color] duration-200;
     border-left: 3px solid transparent;
-    transform-origin: center;
   }
 
   .ledger-row:hover {
     @apply bg-muted/30;
-    border-left-color: hsl(var(--primary));
-    transform: scale(1.002);
-    box-shadow: 0 2px 8px -2px rgba(var(--primary), 0.15),
-                0 0 0 1px rgba(var(--primary), 0.05);
+    border-left-color: var(--primary);
+    box-shadow: 0 2px 8px -2px oklch(from var(--primary) l c h / 0.15),
+                0 0 0 1px oklch(from var(--primary) l c h / 0.05);
   }
 
   .ledger-row-expanded {

--- a/components/AddPersonForm.tsx
+++ b/components/AddPersonForm.tsx
@@ -113,7 +113,7 @@ export const AddPersonForm = forwardRef<HTMLInputElement, AddPersonFormProps>(fu
             size="sm" 
             onClick={handleAddPerson} 
             disabled={!newPersonName.trim()} 
-            className={`h-10 px-4 rounded-xl btn-float transition-[background-color,box-shadow,transform,color] duration-300 ease-out motion-reduce:transition-none font-medium ${showSuccess ? 'bg-success hover:bg-success/90 success-pulse' : 'bg-gradient-to-br from-primary to-primary/90 hover:from-primary-600 hover:to-primary/80 text-white'}`}
+            className={`h-10 px-4 rounded-xl btn-float transition-[background-color,box-shadow,transform,color] duration-200 ease-out motion-reduce:transition-none font-medium ${showSuccess ? 'bg-success hover:bg-success/90 success-pulse' : 'bg-gradient-to-br from-primary to-primary/90 hover:from-primary-600 hover:to-primary/80 text-white'}`}
           >
             {showSuccess ? '✓' : 'Add'}
           </Button>

--- a/components/ProBillSplitter.tsx
+++ b/components/ProBillSplitter.tsx
@@ -1524,7 +1524,7 @@ function DesktopBillSplitter() {
                                         <button
                                           onClick={(e) => e.stopPropagation()}
                                           aria-label="Change split method"
-                                          className="p-1 text-muted-foreground hover:text-primary hover:bg-primary/10 rounded transition-all flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                                          className="p-1 text-muted-foreground hover:text-primary hover:bg-primary/10 rounded transition-[color,background-color,opacity] duration-150 ease-out flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
                                           title="Change split method"
                                         >
                                           {React.createElement(getSplitMethodOption(item.method).icon, { size: 12 })}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-slate-100 data-[state=open]:bg-slate-100",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       inset && "pl-8",
       className
     )}
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-slate-950 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 ease-[cubic-bezier(0.22,1,0.36,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 ease-[cubic-bezier(0.22,1,0.36,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-slate-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 ease-[cubic-bezier(0.22,1,0.36,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 ease-[cubic-bezier(0.22,1,0.36,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className
         )}
       {...props}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -162,7 +162,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-slate-100", className)}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary

A design-engineering pass (Emil Kowalski lens) over the whole app. Two logical commits:

### 1. Correctness — render silently-dead micro-interactions + fix dropdown dark mode
OKLCH design tokens (`--primary`, `--success`) were wrapped in `rgba()`/`hsl()`, which is **invalid CSS** — the browser dropped the whole declaration. These interactions were written but never rendered:

- Badge hover ring
- Input focus tint
- Success ripple keyframe
- New-input pulse hint
- Ledger row hover elevation + blue left-border rail

Converted all to `oklch(from var(--token) l c h / α)` relative-color syntax.

Also tokenized `dropdown-menu.tsx` (hardcoded `bg-white`/`text-slate-950`/`slate-100` → `bg-popover`/`text-popover-foreground`/`accent`/`border`), so the dropdown follows the theme instead of staying white-on-white in dark mode. Now matches `select.tsx`.

### 2. Polish — animation craft
| Change | Why |
| --- | --- |
| `pulse-border` 3×`ease-in-out` → 2×`ease-out` | ~0.9s of nagging → a hint; instant feedback |
| Dropped `scale(1.002)` on ledger row hover | imperceptible motion that only risked text shimmer |
| `transition-all` → explicit props @ 150ms (split-method button) | don't animate layout; name what changes |
| add-person button hover `300ms` → `200ms` | into the responsive band |

## What's already excellent (left untouched)
Strong `cubic-bezier(0.22,1,0.36,1)` ease-out everywhere, origin-aware popovers, center-origin modals, iOS drawer curve with asymmetric enter/exit, proper reduced-motion handling, `btn-press`, tooltip skip-delay.

## Test plan
- [ ] Hover a person badge / ledger row → glow + elevation now visible
- [ ] Focus an input → subtle tint + ring
- [ ] Open a dropdown menu in **dark mode** → themed, not white-on-white
- [ ] Add a person → success pulse; trigger validation → pulse hint reads as a hint

_Note: `tsc`/`build` not run locally — this worktree has no `node_modules`. Changes are CSS values + Tailwind class strings only (no type surface). CI build will confirm._